### PR TITLE
feat: Core domain model - value objects, resources, annotations, error model

### DIFF
--- a/docs/adr/0009-recursive-descent-filter-parser.md
+++ b/docs/adr/0009-recursive-descent-filter-parser.md
@@ -1,0 +1,28 @@
+# ADR-0009: Recursive Descent Filter Parser
+
+## Status
+
+Accepted
+
+## Context
+
+SCIM defines a filter syntax (RFC 7644, Section 3.4.2.2) that supports attribute comparisons, logical operators (and, or, not), grouping with parentheses, and value path filtering. We need a parser that can handle this grammar and produce an AST for evaluation.
+
+## Decision
+
+We will implement a hand-written recursive descent parser for SCIM filters. The parser will produce a sealed class AST hierarchy that can be evaluated by different backends (in-memory, SQL, LDAP).
+
+## Consequences
+
+### Positive
+
+- Full control over error messages and error recovery
+- No external parser generator dependency
+- Sealed class AST enables exhaustive `when` matching
+- Easy to extend for custom filter operators
+
+### Negative
+
+- More code to write and maintain than a parser generator approach
+- Requires thorough testing of edge cases in the grammar
+- Contributors must understand recursive descent parsing

--- a/docs/adr/0010-no-database-opinion.md
+++ b/docs/adr/0010-no-database-opinion.md
@@ -1,0 +1,28 @@
+# ADR-0010: No Database Opinion
+
+## Status
+
+Accepted
+
+## Context
+
+SCIM service providers need to persist resources, but different organizations use different storage backends (PostgreSQL, MongoDB, DynamoDB, LDAP, in-memory). Coupling the SDK to a specific persistence technology would limit adoption.
+
+## Decision
+
+All persistence in the SDK is behind generic interfaces (e.g., `ResourceRepository<T>`). The SDK will not include any JPA, JDBC, or database-specific dependencies. Implementers provide their own persistence adapters.
+
+## Consequences
+
+### Positive
+
+- SDK works with any storage backend
+- No transitive database driver dependencies
+- Clean separation between domain logic and persistence
+- Aligns with hexagonal architecture (ADR-0008)
+
+### Negative
+
+- Implementers must write their own persistence layer
+- Cannot provide out-of-the-box storage without additional modules
+- Common patterns (pagination, filtering) must be well-documented for implementers

--- a/docs/adr/0011-no-idp-opinion.md
+++ b/docs/adr/0011-no-idp-opinion.md
@@ -1,0 +1,28 @@
+# ADR-0011: No IdP Opinion
+
+## Status
+
+Accepted
+
+## Context
+
+SCIM is often deployed alongside identity providers (IdPs) with OIDC, SAML, or other authentication mechanisms. Different organizations use different IdPs (Okta, Azure AD, Keycloak, custom) and authentication strategies.
+
+## Decision
+
+Authentication and authorization in the SDK are behind generic interfaces (`IdentityResolver`, `AuthenticationStrategy`). The SDK will not include any IdP-specific dependencies in core or server modules.
+
+## Consequences
+
+### Positive
+
+- SDK works with any IdP or authentication mechanism
+- No transitive IdP SDK dependencies
+- Implementers choose their own security stack
+- Spring Boot starter can optionally integrate with Spring Security
+
+### Negative
+
+- Implementers must wire their own authentication
+- Cannot provide turnkey IdP integration without additional modules
+- Security misconfiguration risk if implementers skip authentication

--- a/docs/adr/0017-sealed-classes-for-domain-types.md
+++ b/docs/adr/0017-sealed-classes-for-domain-types.md
@@ -1,0 +1,28 @@
+# ADR-0017: Sealed Classes for Domain Types
+
+## Status
+
+Accepted
+
+## Context
+
+The SCIM domain model contains several closed type hierarchies: filter AST nodes, patch operations, bulk operation types, and error types. We need a way to model these hierarchies that enables compile-time exhaustiveness checking.
+
+## Decision
+
+We will use Kotlin sealed classes (and sealed interfaces) for all closed type hierarchies in the domain model. Consumers matching on these types with `when` expressions get compile-time guarantees that all cases are handled, without needing a fallback `else` branch.
+
+## Consequences
+
+### Positive
+
+- Compile-time exhaustiveness checking prevents missing-case bugs
+- Adding a new subtype causes compilation errors at every `when` site, making it impossible to forget
+- Clean pattern matching with smart casts
+- Self-documenting: the sealed hierarchy shows all valid variants
+
+### Negative
+
+- Sealed hierarchies cannot be extended by consumers (closed by design)
+- All subtypes must be in the same package (Kotlin requirement)
+- May require more upfront design to get the hierarchy right

--- a/docs/adr/0018-internal-by-default-visibility.md
+++ b/docs/adr/0018-internal-by-default-visibility.md
@@ -1,0 +1,28 @@
+# ADR-0018: Internal by Default Visibility
+
+## Status
+
+Accepted
+
+## Context
+
+A public SDK must have a well-defined, stable API surface. Exposing too many types as `public` creates a large API surface that is difficult to evolve without breaking changes. Kotlin's `internal` visibility modifier restricts access to the same module, providing a middle ground between `public` and `private`.
+
+## Decision
+
+All classes, functions, and properties will be `internal` by default. Only types that form the explicit public API surface will be marked `public`. This applies to all SDK modules.
+
+## Consequences
+
+### Positive
+
+- Small, deliberate public API surface that is easy to maintain and evolve
+- Internal implementation details can change freely between releases
+- Reduces risk of consumers depending on unstable internals
+- Forces explicit decisions about what is part of the public API
+
+### Negative
+
+- Requires discipline to mark the right things as public
+- `internal` types are not accessible from Java (they become `public` with a mangled name)
+- May initially frustrate contributors who forget to add `public` visibility

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <java.version>25</java.version>
+        <kotlin.jvm-target>23</kotlin.jvm-target>
         <kotlin.version>2.1.20</kotlin.version>
         <jackson.version>2.18.3</jackson.version>
         <junit.version>5.11.4</junit.version>
@@ -197,7 +198,7 @@
                     <artifactId>kotlin-maven-plugin</artifactId>
                     <version>${kotlin.version}</version>
                     <configuration>
-                        <jvmTarget>${java.version}</jvmTarget>
+                        <jvmTarget>${kotlin.jvm-target}</jvmTarget>
                     </configuration>
                     <executions>
                         <execution>

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Address.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Address.kt
@@ -1,0 +1,12 @@
+package com.marcosbarbero.scim2.core.domain.model.common
+
+data class Address(
+    val formatted: String? = null,
+    val streetAddress: String? = null,
+    val locality: String? = null,
+    val region: String? = null,
+    val postalCode: String? = null,
+    val country: String? = null,
+    val type: String? = null,
+    val primary: Boolean? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/GroupMembership.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/GroupMembership.kt
@@ -1,0 +1,12 @@
+package com.marcosbarbero.scim2.core.domain.model.common
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.net.URI
+
+data class GroupMembership(
+    val value: String? = null,
+    @JsonProperty("\$ref")
+    val ref: URI? = null,
+    val display: String? = null,
+    val type: String? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Manager.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Manager.kt
@@ -1,0 +1,11 @@
+package com.marcosbarbero.scim2.core.domain.model.common
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.net.URI
+
+data class Manager(
+    val value: String? = null,
+    @JsonProperty("\$ref")
+    val ref: URI? = null,
+    val displayName: String? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Meta.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Meta.kt
@@ -1,0 +1,13 @@
+package com.marcosbarbero.scim2.core.domain.model.common
+
+import com.marcosbarbero.scim2.core.domain.vo.ETag
+import java.net.URI
+import java.time.Instant
+
+data class Meta(
+    val resourceType: String? = null,
+    val created: Instant? = null,
+    val lastModified: Instant? = null,
+    val location: URI? = null,
+    val version: ETag? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/MultiValuedAttribute.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/MultiValuedAttribute.kt
@@ -1,0 +1,12 @@
+package com.marcosbarbero.scim2.core.domain.model.common
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class MultiValuedAttribute(
+    val value: String? = null,
+    val display: String? = null,
+    val type: String? = null,
+    val primary: Boolean? = null,
+    @JsonProperty("\$ref")
+    val ref: String? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Name.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/common/Name.kt
@@ -1,0 +1,10 @@
+package com.marcosbarbero.scim2.core.domain.model.common
+
+data class Name(
+    val formatted: String? = null,
+    val familyName: String? = null,
+    val givenName: String? = null,
+    val middleName: String? = null,
+    val honorificPrefix: String? = null,
+    val honorificSuffix: String? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimError.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimError.kt
@@ -1,0 +1,8 @@
+package com.marcosbarbero.scim2.core.domain.model.error
+
+data class ScimError(
+    val schemas: List<String> = listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
+    val status: String,
+    val scimType: String? = null,
+    val detail: String? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimErrorType.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimErrorType.kt
@@ -1,0 +1,14 @@
+package com.marcosbarbero.scim2.core.domain.model.error
+
+enum class ScimErrorType(val value: String) {
+    INVALID_FILTER("invalidFilter"),
+    TOO_MANY("tooMany"),
+    UNIQUENESS("uniqueness"),
+    MUTABILITY("mutability"),
+    INVALID_SYNTAX("invalidSyntax"),
+    INVALID_PATH("invalidPath"),
+    NO_TARGET("noTarget"),
+    INVALID_VALUE("invalidValue"),
+    INVALID_VERS("invalidVers"),
+    SENSITIVE("sensitive")
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimException.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimException.kt
@@ -1,0 +1,45 @@
+package com.marcosbarbero.scim2.core.domain.model.error
+
+open class ScimException(
+    val status: Int,
+    val scimType: ScimErrorType? = null,
+    val detail: String? = null
+) : RuntimeException(detail) {
+
+    fun toScimError(): ScimError = ScimError(
+        schemas = listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
+        status = status.toString(),
+        scimType = scimType?.value,
+        detail = detail
+    )
+}
+
+class ResourceNotFoundException(detail: String? = null) :
+    ScimException(status = 404, detail = detail)
+
+class ResourceConflictException(detail: String? = null) :
+    ScimException(status = 409, scimType = ScimErrorType.UNIQUENESS, detail = detail)
+
+class InvalidFilterException(detail: String? = null) :
+    ScimException(status = 400, scimType = ScimErrorType.INVALID_FILTER, detail = detail)
+
+class InvalidPathException(detail: String? = null) :
+    ScimException(status = 400, scimType = ScimErrorType.INVALID_PATH, detail = detail)
+
+class MutabilityException(detail: String? = null) :
+    ScimException(status = 400, scimType = ScimErrorType.MUTABILITY, detail = detail)
+
+class InvalidSyntaxException(detail: String? = null) :
+    ScimException(status = 400, scimType = ScimErrorType.INVALID_SYNTAX, detail = detail)
+
+class NoTargetException(detail: String? = null) :
+    ScimException(status = 400, scimType = ScimErrorType.NO_TARGET, detail = detail)
+
+class InvalidValueException(detail: String? = null) :
+    ScimException(status = 400, scimType = ScimErrorType.INVALID_VALUE, detail = detail)
+
+class TooManyException(detail: String? = null) :
+    ScimException(status = 400, scimType = ScimErrorType.TOO_MANY, detail = detail)
+
+class SensitiveException(detail: String? = null) :
+    ScimException(status = 403, scimType = ScimErrorType.SENSITIVE, detail = detail)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/EnterpriseUserExtension.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/EnterpriseUserExtension.kt
@@ -1,0 +1,14 @@
+package com.marcosbarbero.scim2.core.domain.model.resource
+
+import com.marcosbarbero.scim2.core.domain.model.common.Manager
+import com.marcosbarbero.scim2.core.schema.annotation.ScimExtension
+
+@ScimExtension(schema = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User")
+data class EnterpriseUserExtension(
+    val employeeNumber: String? = null,
+    val costCenter: String? = null,
+    val organization: String? = null,
+    val division: String? = null,
+    val department: String? = null,
+    val manager: Manager? = null
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/Group.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/Group.kt
@@ -1,0 +1,27 @@
+package com.marcosbarbero.scim2.core.domain.model.resource
+
+import com.marcosbarbero.scim2.core.domain.model.common.GroupMembership
+import com.marcosbarbero.scim2.core.domain.model.common.Meta
+import com.marcosbarbero.scim2.core.schema.annotation.ScimAttribute
+
+@com.marcosbarbero.scim2.core.schema.annotation.ScimResource(
+    schema = "urn:ietf:params:scim:schemas:core:2.0:Group",
+    name = "Group",
+    description = "Group",
+    endpoint = "/Groups"
+)
+data class Group(
+    override val id: String? = null,
+    override val externalId: String? = null,
+    override val meta: Meta? = null,
+
+    @ScimAttribute(required = true)
+    val displayName: String,
+
+    val members: List<GroupMembership> = emptyList()
+) : ScimResource(
+    schemas = listOf("urn:ietf:params:scim:schemas:core:2.0:Group"),
+    id = id,
+    externalId = externalId,
+    meta = meta
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResource.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResource.kt
@@ -1,0 +1,25 @@
+package com.marcosbarbero.scim2.core.domain.model.resource
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.marcosbarbero.scim2.core.domain.model.common.Meta
+
+abstract class ScimResource(
+    open val schemas: List<String>,
+    open val id: String? = null,
+    open val externalId: String? = null,
+    open val meta: Meta? = null
+) {
+    private val _extensions: MutableMap<String, Any> = mutableMapOf()
+
+    @get:JsonAnyGetter
+    val extensions: Map<String, Any> get() = _extensions
+
+    @JsonAnySetter
+    fun setExtension(key: String, value: Any) {
+        _extensions[key] = value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> getExtension(schema: String): T? = _extensions[schema] as? T
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/User.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/User.kt
@@ -1,0 +1,56 @@
+package com.marcosbarbero.scim2.core.domain.model.resource
+
+import com.marcosbarbero.scim2.core.domain.model.common.Address
+import com.marcosbarbero.scim2.core.domain.model.common.GroupMembership
+import com.marcosbarbero.scim2.core.domain.model.common.Meta
+import com.marcosbarbero.scim2.core.domain.model.common.MultiValuedAttribute
+import com.marcosbarbero.scim2.core.domain.model.common.Name
+import com.marcosbarbero.scim2.core.schema.annotation.ScimAttribute
+import com.marcosbarbero.scim2.core.schema.annotation.Mutability
+import com.marcosbarbero.scim2.core.schema.annotation.Returned
+import com.marcosbarbero.scim2.core.schema.annotation.Uniqueness
+import java.net.URI
+
+@com.marcosbarbero.scim2.core.schema.annotation.ScimResource(
+    schema = "urn:ietf:params:scim:schemas:core:2.0:User",
+    name = "User",
+    description = "User Account",
+    endpoint = "/Users"
+)
+data class User(
+    override val id: String? = null,
+    override val externalId: String? = null,
+    override val meta: Meta? = null,
+
+    @ScimAttribute(required = true, uniqueness = Uniqueness.SERVER)
+    val userName: String,
+
+    val name: Name? = null,
+    val displayName: String? = null,
+    val nickName: String? = null,
+    val profileUrl: URI? = null,
+    val title: String? = null,
+    val userType: String? = null,
+    val preferredLanguage: String? = null,
+    val locale: String? = null,
+    val timezone: String? = null,
+    val active: Boolean? = null,
+
+    @ScimAttribute(mutability = Mutability.WRITE_ONLY, returned = Returned.NEVER)
+    val password: String? = null,
+
+    val emails: List<MultiValuedAttribute> = emptyList(),
+    val phoneNumbers: List<MultiValuedAttribute> = emptyList(),
+    val ims: List<MultiValuedAttribute> = emptyList(),
+    val photos: List<MultiValuedAttribute> = emptyList(),
+    val addresses: List<Address> = emptyList(),
+    val groups: List<GroupMembership> = emptyList(),
+    val entitlements: List<MultiValuedAttribute> = emptyList(),
+    val roles: List<MultiValuedAttribute> = emptyList(),
+    val x509Certificates: List<MultiValuedAttribute> = emptyList()
+) : ScimResource(
+    schemas = listOf("urn:ietf:params:scim:schemas:core:2.0:User"),
+    id = id,
+    externalId = externalId,
+    meta = meta
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/vo/ETag.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/vo/ETag.kt
@@ -1,0 +1,6 @@
+package com.marcosbarbero.scim2.core.domain.vo
+
+@JvmInline
+value class ETag(val value: String) {
+    override fun toString(): String = value
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/vo/ResourceId.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/vo/ResourceId.kt
@@ -1,0 +1,10 @@
+package com.marcosbarbero.scim2.core.domain.vo
+
+@JvmInline
+value class ResourceId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "ResourceId must not be blank" }
+    }
+
+    override fun toString(): String = value
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/vo/SchemaUri.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/vo/SchemaUri.kt
@@ -1,0 +1,11 @@
+package com.marcosbarbero.scim2.core.domain.vo
+
+@JvmInline
+value class SchemaUri(val value: String) {
+    init {
+        require(value.isNotBlank()) { "SchemaUri must not be blank" }
+        require(value.startsWith("urn:")) { "SchemaUri must start with 'urn:'" }
+    }
+
+    override fun toString(): String = value
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/annotation/Annotations.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/annotation/Annotations.kt
@@ -1,0 +1,31 @@
+package com.marcosbarbero.scim2.core.schema.annotation
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ScimResource(
+    val schema: String,
+    val name: String,
+    val description: String = "",
+    val endpoint: String = ""
+)
+
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ScimAttribute(
+    val name: String = "",
+    val type: AttributeType = AttributeType.STRING,
+    val mutability: Mutability = Mutability.READ_WRITE,
+    val returned: Returned = Returned.DEFAULT,
+    val uniqueness: Uniqueness = Uniqueness.NONE,
+    val required: Boolean = false,
+    val caseExact: Boolean = false,
+    val multiValued: Boolean = false,
+    val description: String = ""
+)
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Repeatable
+annotation class ScimExtension(
+    val schema: String
+)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/annotation/Enums.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/annotation/Enums.kt
@@ -1,0 +1,17 @@
+package com.marcosbarbero.scim2.core.schema.annotation
+
+enum class AttributeType {
+    STRING, BOOLEAN, DECIMAL, INTEGER, DATE_TIME, BINARY, REFERENCE, COMPLEX
+}
+
+enum class Mutability {
+    READ_ONLY, READ_WRITE, IMMUTABLE, WRITE_ONLY
+}
+
+enum class Returned {
+    ALWAYS, NEVER, DEFAULT, REQUEST
+}
+
+enum class Uniqueness {
+    NONE, SERVER, GLOBAL
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimErrorTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimErrorTest.kt
@@ -1,0 +1,173 @@
+package com.marcosbarbero.scim2.core.domain.model.error
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ScimErrorTest {
+
+    @Nested
+    inner class ScimExceptionHierarchyTest {
+
+        @Test
+        fun `ResourceNotFoundException should have status 404`() {
+            val ex = ResourceNotFoundException("User not found")
+            ex.status shouldBe 404
+            ex.detail shouldBe "User not found"
+            ex.scimType.shouldBe(null)
+        }
+
+        @Test
+        fun `ResourceConflictException should have status 409`() {
+            val ex = ResourceConflictException("User already exists")
+            ex.status shouldBe 409
+            ex.scimType shouldBe ScimErrorType.UNIQUENESS
+        }
+
+        @Test
+        fun `InvalidFilterException should have status 400 and scimType invalidFilter`() {
+            val ex = InvalidFilterException("Bad filter")
+            ex.status shouldBe 400
+            ex.scimType shouldBe ScimErrorType.INVALID_FILTER
+        }
+
+        @Test
+        fun `InvalidPathException should have status 400 and scimType invalidPath`() {
+            val ex = InvalidPathException("Bad path")
+            ex.status shouldBe 400
+            ex.scimType shouldBe ScimErrorType.INVALID_PATH
+        }
+
+        @Test
+        fun `MutabilityException should have status 400 and scimType mutability`() {
+            val ex = MutabilityException("Cannot modify read-only attribute")
+            ex.status shouldBe 400
+            ex.scimType shouldBe ScimErrorType.MUTABILITY
+        }
+
+        @Test
+        fun `InvalidSyntaxException should have status 400 and scimType invalidSyntax`() {
+            val ex = InvalidSyntaxException("Bad syntax")
+            ex.status shouldBe 400
+            ex.scimType shouldBe ScimErrorType.INVALID_SYNTAX
+        }
+
+        @Test
+        fun `NoTargetException should have status 400 and scimType noTarget`() {
+            val ex = NoTargetException("No target")
+            ex.status shouldBe 400
+            ex.scimType shouldBe ScimErrorType.NO_TARGET
+        }
+
+        @Test
+        fun `InvalidValueException should have status 400 and scimType invalidValue`() {
+            val ex = InvalidValueException("Bad value")
+            ex.status shouldBe 400
+            ex.scimType shouldBe ScimErrorType.INVALID_VALUE
+        }
+
+        @Test
+        fun `TooManyException should have status 400 and scimType tooMany`() {
+            val ex = TooManyException("Too many results")
+            ex.status shouldBe 400
+            ex.scimType shouldBe ScimErrorType.TOO_MANY
+        }
+
+        @Test
+        fun `SensitiveException should have status 403 and scimType sensitive`() {
+            val ex = SensitiveException("Sensitive attribute")
+            ex.status shouldBe 403
+            ex.scimType shouldBe ScimErrorType.SENSITIVE
+        }
+
+        @Test
+        fun `all exceptions should extend ScimException`() {
+            val exceptions: List<ScimException> = listOf(
+                ResourceNotFoundException("test"),
+                ResourceConflictException("test"),
+                InvalidFilterException("test"),
+                InvalidPathException("test"),
+                MutabilityException("test"),
+                InvalidSyntaxException("test"),
+                NoTargetException("test"),
+                InvalidValueException("test"),
+                TooManyException("test"),
+                SensitiveException("test")
+            )
+            exceptions.forEach { it.shouldBeInstanceOf<ScimException>() }
+        }
+    }
+
+    @Nested
+    inner class ScimErrorTypeTest {
+
+        @Test
+        fun `enum values should match RFC 7644 wire values`() {
+            ScimErrorType.INVALID_FILTER.value shouldBe "invalidFilter"
+            ScimErrorType.TOO_MANY.value shouldBe "tooMany"
+            ScimErrorType.UNIQUENESS.value shouldBe "uniqueness"
+            ScimErrorType.MUTABILITY.value shouldBe "mutability"
+            ScimErrorType.INVALID_SYNTAX.value shouldBe "invalidSyntax"
+            ScimErrorType.INVALID_PATH.value shouldBe "invalidPath"
+            ScimErrorType.NO_TARGET.value shouldBe "noTarget"
+            ScimErrorType.INVALID_VALUE.value shouldBe "invalidValue"
+            ScimErrorType.INVALID_VERS.value shouldBe "invalidVers"
+            ScimErrorType.SENSITIVE.value shouldBe "sensitive"
+        }
+    }
+
+    @Nested
+    inner class ScimErrorWireFormatTest {
+
+        private val mapper: ObjectMapper = jacksonObjectMapper()
+
+        @Test
+        fun `should serialize ScimError to JSON`() {
+            val error = ScimError(
+                schemas = listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
+                status = "400",
+                scimType = "invalidFilter",
+                detail = "The filter syntax is invalid"
+            )
+
+            val json = mapper.writeValueAsString(error)
+            val deserialized = mapper.readValue<ScimError>(json)
+
+            deserialized.status shouldBe "400"
+            deserialized.scimType shouldBe "invalidFilter"
+            deserialized.detail shouldBe "The filter syntax is invalid"
+            deserialized.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:Error")
+        }
+
+        @Test
+        fun `should deserialize ScimError from JSON`() {
+            val json = """
+            {
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+                "status": "404",
+                "detail": "Resource not found"
+            }
+            """.trimIndent()
+
+            val error = mapper.readValue<ScimError>(json)
+            error.status shouldBe "404"
+            error.scimType shouldBe null
+            error.detail shouldBe "Resource not found"
+        }
+
+        @Test
+        fun `ScimException should convert to ScimError`() {
+            val ex = InvalidFilterException("Bad filter expression")
+            val error = ex.toScimError()
+
+            error.status shouldBe "400"
+            error.scimType shouldBe "invalidFilter"
+            error.detail shouldBe "Bad filter expression"
+            error.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:Error")
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResourceTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResourceTest.kt
@@ -1,0 +1,206 @@
+package com.marcosbarbero.scim2.core.domain.model.resource
+
+import com.marcosbarbero.scim2.core.domain.model.common.Address
+import com.marcosbarbero.scim2.core.domain.model.common.GroupMembership
+import com.marcosbarbero.scim2.core.domain.model.common.Meta
+import com.marcosbarbero.scim2.core.domain.model.common.MultiValuedAttribute
+import com.marcosbarbero.scim2.core.domain.model.common.Name
+import com.marcosbarbero.scim2.core.domain.vo.ETag
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.time.Instant
+
+class ScimResourceTest {
+
+    @Nested
+    inner class UserTest {
+
+        @Test
+        fun `should create User with required userName`() {
+            val user = User(userName = "bjensen")
+            user.userName shouldBe "bjensen"
+            user.schemas shouldContain "urn:ietf:params:scim:schemas:core:2.0:User"
+        }
+
+        @Test
+        fun `should create User with all attributes`() {
+            val now = Instant.now()
+            val user = User(
+                id = "2819c223-7f76-453a-919d-413861904646",
+                externalId = "bjensen",
+                meta = Meta(
+                    resourceType = "User",
+                    created = now,
+                    lastModified = now,
+                    location = URI.create("https://example.com/v2/Users/2819c223"),
+                    version = ETag("W/\"a330bc54f0671c9\"")
+                ),
+                userName = "bjensen@example.com",
+                name = Name(
+                    formatted = "Ms. Barbara J Jensen III",
+                    familyName = "Jensen",
+                    givenName = "Barbara",
+                    middleName = "Jane",
+                    honorificPrefix = "Ms.",
+                    honorificSuffix = "III"
+                ),
+                displayName = "Babs Jensen",
+                nickName = "Babs",
+                profileUrl = URI.create("https://login.example.com/bjensen"),
+                title = "Tour Guide",
+                userType = "Employee",
+                preferredLanguage = "en-US",
+                locale = "en-US",
+                timezone = "America/Los_Angeles",
+                active = true,
+                password = null,
+                emails = listOf(
+                    MultiValuedAttribute(value = "bjensen@example.com", type = "work", primary = true)
+                ),
+                phoneNumbers = listOf(
+                    MultiValuedAttribute(value = "555-555-5555", type = "work")
+                ),
+                ims = listOf(
+                    MultiValuedAttribute(value = "someaimhandle", type = "aim")
+                ),
+                photos = listOf(
+                    MultiValuedAttribute(
+                        value = "https://photos.example.com/profilephoto/72930000000Ccne/F",
+                        type = "photo"
+                    )
+                ),
+                addresses = listOf(
+                    Address(
+                        streetAddress = "100 Universal City Plaza",
+                        locality = "Hollywood",
+                        region = "CA",
+                        postalCode = "91608",
+                        country = "US",
+                        type = "work",
+                        primary = true
+                    )
+                ),
+                groups = listOf(
+                    GroupMembership(value = "e9e30dba-f08f-4109-8486-d5c6a331660a", display = "Tour Guides")
+                ),
+                entitlements = listOf(
+                    MultiValuedAttribute(value = "admin")
+                ),
+                roles = listOf(
+                    MultiValuedAttribute(value = "manager")
+                ),
+                x509Certificates = emptyList()
+            )
+
+            user.userName shouldBe "bjensen@example.com"
+            user.name.shouldNotBeNull()
+            user.name!!.familyName shouldBe "Jensen"
+            user.displayName shouldBe "Babs Jensen"
+            user.active shouldBe true
+            user.emails shouldHaveSize 1
+            user.addresses shouldHaveSize 1
+            user.groups shouldHaveSize 1
+            user.meta.shouldNotBeNull()
+            user.meta!!.version.shouldNotBeNull()
+        }
+
+        @Test
+        fun `should default optional fields to null or empty`() {
+            val user = User(userName = "simple")
+            user.name.shouldBeNull()
+            user.displayName.shouldBeNull()
+            user.active.shouldBeNull()
+            user.emails shouldBe emptyList()
+            user.phoneNumbers shouldBe emptyList()
+            user.addresses shouldBe emptyList()
+            user.groups shouldBe emptyList()
+        }
+
+        @Test
+        fun `should support extensions via map`() {
+            val user = User(userName = "bjensen")
+            val ext = EnterpriseUserExtension(
+                employeeNumber = "701984",
+                costCenter = "4130",
+                organization = "Universal Studios",
+                division = "Theme Park",
+                department = "Tour Operations"
+            )
+            user.setExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", ext)
+
+            user.extensions shouldContainKey "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            val retrieved = user.getExtension<EnterpriseUserExtension>(
+                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            )
+            retrieved.shouldNotBeNull()
+            retrieved.employeeNumber shouldBe "701984"
+        }
+    }
+
+    @Nested
+    inner class GroupTest {
+
+        @Test
+        fun `should create Group with required displayName`() {
+            val group = Group(displayName = "Tour Guides")
+            group.displayName shouldBe "Tour Guides"
+            group.schemas shouldContain "urn:ietf:params:scim:schemas:core:2.0:Group"
+        }
+
+        @Test
+        fun `should create Group with members`() {
+            val group = Group(
+                displayName = "Tour Guides",
+                members = listOf(
+                    GroupMembership(
+                        value = "2819c223-7f76-453a-919d-413861904646",
+                        display = "Babs Jensen",
+                        ref = URI.create("https://example.com/v2/Users/2819c223"),
+                        type = "User"
+                    )
+                )
+            )
+
+            group.members shouldHaveSize 1
+            group.members[0].display shouldBe "Babs Jensen"
+        }
+    }
+
+    @Nested
+    inner class EnterpriseUserExtensionTest {
+
+        @Test
+        fun `should create extension with all fields`() {
+            val ext = EnterpriseUserExtension(
+                employeeNumber = "701984",
+                costCenter = "4130",
+                organization = "Universal Studios",
+                division = "Theme Park",
+                department = "Tour Operations",
+                manager = com.marcosbarbero.scim2.core.domain.model.common.Manager(
+                    value = "26118915-6090-4610-87e4-49d8ca9f808d",
+                    ref = URI.create("https://example.com/v2/Users/26118915"),
+                    displayName = "John Smith"
+                )
+            )
+
+            ext.employeeNumber shouldBe "701984"
+            ext.manager.shouldNotBeNull()
+            ext.manager!!.displayName shouldBe "John Smith"
+        }
+
+        @Test
+        fun `should default optional fields to null`() {
+            val ext = EnterpriseUserExtension()
+            ext.employeeNumber.shouldBeNull()
+            ext.manager.shouldBeNull()
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/vo/ValueObjectsTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/vo/ValueObjectsTest.kt
@@ -1,0 +1,85 @@
+package com.marcosbarbero.scim2.core.domain.vo
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ValueObjectsTest {
+
+    @Nested
+    inner class SchemaUriTest {
+
+        @Test
+        fun `should create SchemaUri with valid URN`() {
+            val uri = SchemaUri("urn:ietf:params:scim:schemas:core:2.0:User")
+            uri.value shouldBe "urn:ietf:params:scim:schemas:core:2.0:User"
+        }
+
+        @Test
+        fun `should reject SchemaUri not starting with urn`() {
+            shouldThrow<IllegalArgumentException> {
+                SchemaUri("http://example.com/schema")
+            }
+        }
+
+        @Test
+        fun `should reject blank SchemaUri`() {
+            shouldThrow<IllegalArgumentException> {
+                SchemaUri("   ")
+            }
+        }
+
+        @Test
+        fun `toString returns the value`() {
+            val uri = SchemaUri("urn:ietf:params:scim:schemas:core:2.0:User")
+            uri.toString() shouldBe "urn:ietf:params:scim:schemas:core:2.0:User"
+        }
+    }
+
+    @Nested
+    inner class ResourceIdTest {
+
+        @Test
+        fun `should create ResourceId with valid value`() {
+            val id = ResourceId("abc-123")
+            id.value shouldBe "abc-123"
+        }
+
+        @Test
+        fun `should reject blank ResourceId`() {
+            shouldThrow<IllegalArgumentException> {
+                ResourceId("")
+            }
+        }
+
+        @Test
+        fun `should reject whitespace-only ResourceId`() {
+            shouldThrow<IllegalArgumentException> {
+                ResourceId("   ")
+            }
+        }
+
+        @Test
+        fun `toString returns the value`() {
+            val id = ResourceId("abc-123")
+            id.toString() shouldBe "abc-123"
+        }
+    }
+
+    @Nested
+    inner class ETagTest {
+
+        @Test
+        fun `should create ETag with value`() {
+            val etag = ETag("W/\"abc\"")
+            etag.value shouldBe "W/\"abc\""
+        }
+
+        @Test
+        fun `toString returns the value`() {
+            val etag = ETag("W/\"abc\"")
+            etag.toString() shouldBe "W/\"abc\""
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/annotation/AnnotationsTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/annotation/AnnotationsTest.kt
@@ -1,0 +1,64 @@
+package com.marcosbarbero.scim2.core.schema.annotation
+
+import com.marcosbarbero.scim2.core.domain.model.resource.EnterpriseUserExtension
+import com.marcosbarbero.scim2.core.domain.model.resource.Group
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class AnnotationsTest {
+
+    @Test
+    fun `User class should have ScimResource annotation`() {
+        val annotation = User::class.java.getAnnotation(ScimResource::class.java)
+        annotation.shouldNotBeNull()
+        annotation.schema shouldBe "urn:ietf:params:scim:schemas:core:2.0:User"
+        annotation.name shouldBe "User"
+        annotation.endpoint shouldBe "/Users"
+    }
+
+    @Test
+    fun `Group class should have ScimResource annotation`() {
+        val annotation = Group::class.java.getAnnotation(ScimResource::class.java)
+        annotation.shouldNotBeNull()
+        annotation.schema shouldBe "urn:ietf:params:scim:schemas:core:2.0:Group"
+        annotation.name shouldBe "Group"
+        annotation.endpoint shouldBe "/Groups"
+    }
+
+    @Test
+    fun `EnterpriseUserExtension should have ScimExtension annotation`() {
+        val annotation = EnterpriseUserExtension::class.java.getAnnotation(ScimExtension::class.java)
+        annotation.shouldNotBeNull()
+        annotation.schema shouldBe "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+    }
+
+    @Test
+    fun `AttributeType should have expected values`() {
+        AttributeType.entries.map { it.name } shouldBe listOf(
+            "STRING", "BOOLEAN", "DECIMAL", "INTEGER", "DATE_TIME", "BINARY", "REFERENCE", "COMPLEX"
+        )
+    }
+
+    @Test
+    fun `Mutability should have expected values`() {
+        Mutability.entries.map { it.name } shouldBe listOf(
+            "READ_ONLY", "READ_WRITE", "IMMUTABLE", "WRITE_ONLY"
+        )
+    }
+
+    @Test
+    fun `Returned should have expected values`() {
+        Returned.entries.map { it.name } shouldBe listOf(
+            "ALWAYS", "NEVER", "DEFAULT", "REQUEST"
+        )
+    }
+
+    @Test
+    fun `Uniqueness should have expected values`() {
+        Uniqueness.entries.map { it.name } shouldBe listOf(
+            "NONE", "SERVER", "GLOBAL"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Implement foundational domain model in `scim2-sdk-core` with TDD (tests first, 40 tests passing)
- Add value objects (`SchemaUri`, `ResourceId`, `ETag`) with validation
- Add SCIM resource model (`User`, `Group`, `EnterpriseUserExtension`) with full RFC 7643 attributes
- Add error model with `ScimException` hierarchy mapping to RFC 7644 error types
- Add schema annotations (`@ScimResource`, `@ScimAttribute`, `@ScimExtension`) and enums
- Create ADRs 0009-0011, 0017-0018

## Details

### Package Structure (`com.marcosbarbero.scim2.core`)
| Package | Contents |
|---------|----------|
| `domain/vo/` | `SchemaUri`, `ResourceId`, `ETag` value objects |
| `domain/model/common/` | `Meta`, `Name`, `Address`, `MultiValuedAttribute`, `GroupMembership`, `Manager` |
| `domain/model/resource/` | `ScimResource` (abstract), `User`, `Group`, `EnterpriseUserExtension` |
| `domain/model/error/` | `ScimErrorType`, `ScimException` + 10 subclasses, `ScimError` wire format |
| `schema/annotation/` | `@ScimResource`, `@ScimAttribute`, `@ScimExtension`, enums |

### ADRs
- **0009** — Recursive descent filter parser
- **0010** — No database opinion
- **0011** — No IdP opinion
- **0017** — Sealed classes for domain types
- **0018** — Internal by default visibility

### Parent POM Fix
- Added `kotlin.jvm-target=23` property (Kotlin 2.1.20 max supported target) separate from `java.version=25`

## Test plan

- [x] 40 tests passing: value object validation, User/Group creation, extension get/set, exception hierarchy status codes, ScimError Jackson round-trip
- [x] Full reactor `mvn clean verify -B` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)