### PR TITLE
feat: Filter lexer, parser, AST, and visitors

### DIFF
--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/AttributePath.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/AttributePath.kt
@@ -1,0 +1,19 @@
+package com.marcosbarbero.scim2.core.filter.ast
+
+data class AttributePath(
+    val schemaUri: String? = null,
+    val attributeName: String,
+    val subAttribute: String? = null
+) {
+    fun toFullPath(): String = buildString {
+        if (schemaUri != null) {
+            append(schemaUri)
+            append(":")
+        }
+        append(attributeName)
+        if (subAttribute != null) {
+            append(".")
+            append(subAttribute)
+        }
+    }
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/Enums.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/Enums.kt
@@ -1,0 +1,9 @@
+package com.marcosbarbero.scim2.core.filter.ast
+
+enum class ComparisonOperator {
+    EQ, NE, CO, SW, EW, GT, GE, LT, LE
+}
+
+enum class LogicalOperator {
+    AND, OR
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/FilterNode.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/FilterNode.kt
@@ -1,0 +1,29 @@
+package com.marcosbarbero.scim2.core.filter.ast
+
+sealed class FilterNode
+
+data class AttributeExpression(
+    val path: AttributePath,
+    val operator: ComparisonOperator,
+    val value: ScimValue
+) : FilterNode()
+
+data class PresentExpression(
+    val path: AttributePath
+) : FilterNode()
+
+data class LogicalExpression(
+    val operator: LogicalOperator,
+    val left: FilterNode,
+    val right: FilterNode
+) : FilterNode()
+
+data class NotExpression(
+    val operand: FilterNode
+) : FilterNode()
+
+data class ValuePathExpression(
+    val attributePath: String,
+    val filter: FilterNode,
+    val subAttribute: String? = null
+) : FilterNode()

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/ScimValue.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/ScimValue.kt
@@ -1,0 +1,8 @@
+package com.marcosbarbero.scim2.core.filter.ast
+
+sealed class ScimValue {
+    data class StringValue(val value: String) : ScimValue()
+    data class NumberValue(val value: Number) : ScimValue()
+    data class BooleanValue(val value: Boolean) : ScimValue()
+    data object NullValue : ScimValue()
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/lexer/FilterLexer.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/lexer/FilterLexer.kt
@@ -1,0 +1,119 @@
+package com.marcosbarbero.scim2.core.filter.lexer
+
+import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
+
+class FilterLexer(private val input: String) {
+
+    private var pos = 0
+    private val tokens = mutableListOf<Token>()
+
+    companion object {
+        private val KEYWORD_MAP = mapOf(
+            "eq" to TokenType.OP_EQ,
+            "ne" to TokenType.OP_NE,
+            "co" to TokenType.OP_CO,
+            "sw" to TokenType.OP_SW,
+            "ew" to TokenType.OP_EW,
+            "gt" to TokenType.OP_GT,
+            "ge" to TokenType.OP_GE,
+            "lt" to TokenType.OP_LT,
+            "le" to TokenType.OP_LE,
+            "pr" to TokenType.OP_PR,
+            "and" to TokenType.OP_AND,
+            "or" to TokenType.OP_OR,
+            "not" to TokenType.OP_NOT
+        )
+    }
+
+    fun tokenize(): List<Token> {
+        while (pos < input.length) {
+            skipWhitespace()
+            if (pos >= input.length) break
+
+            val ch = input[pos]
+            when {
+                ch == '"' -> readString()
+                ch == '(' -> { tokens.add(Token(TokenType.LPAREN, "(", pos)); pos++ }
+                ch == ')' -> { tokens.add(Token(TokenType.RPAREN, ")", pos)); pos++ }
+                ch == '[' -> { tokens.add(Token(TokenType.LBRACKET, "[", pos)); pos++ }
+                ch == ']' -> { tokens.add(Token(TokenType.RBRACKET, "]", pos)); pos++ }
+                ch == '-' || ch.isDigit() -> readNumber()
+                ch.isLetter() || ch == '_' -> readWord()
+                ch == '.' && pos + 1 < input.length && input[pos + 1].isLetter() -> readWord()
+                else -> throw InvalidFilterException(
+                    "Unexpected character '$ch' at position $pos"
+                )
+            }
+        }
+        tokens.add(Token(TokenType.EOF, "", pos))
+        return tokens
+    }
+
+    private fun skipWhitespace() {
+        while (pos < input.length && input[pos].isWhitespace()) pos++
+    }
+
+    private fun readString() {
+        val start = pos
+        pos++ // skip opening quote
+        val sb = StringBuilder()
+        while (pos < input.length) {
+            val ch = input[pos]
+            if (ch == '\\' && pos + 1 < input.length) {
+                when (input[pos + 1]) {
+                    '"' -> { sb.append('"'); pos += 2 }
+                    '\\' -> { sb.append('\\'); pos += 2 }
+                    'n' -> { sb.append('\n'); pos += 2 }
+                    't' -> { sb.append('\t'); pos += 2 }
+                    else -> { sb.append(ch); pos++ }
+                }
+            } else if (ch == '"') {
+                pos++ // skip closing quote
+                tokens.add(Token(TokenType.STRING_VALUE, sb.toString(), start))
+                return
+            } else {
+                sb.append(ch)
+                pos++
+            }
+        }
+        throw InvalidFilterException("Unterminated string starting at position $start")
+    }
+
+    private fun readNumber() {
+        val start = pos
+        if (input[pos] == '-') pos++
+        while (pos < input.length && input[pos].isDigit()) pos++
+        if (pos < input.length && input[pos] == '.') {
+            pos++
+            while (pos < input.length && input[pos].isDigit()) pos++
+        }
+        tokens.add(Token(TokenType.NUMBER_VALUE, input.substring(start, pos), start))
+    }
+
+    private fun readWord() {
+        val start = pos
+        // Read a word that can contain letters, digits, underscores, dots, colons (for URN paths), hyphens
+        while (pos < input.length && (input[pos].isLetterOrDigit() || input[pos] == '_' || input[pos] == '.' || input[pos] == ':' || input[pos] == '-')) {
+            pos++
+        }
+        val word = input.substring(start, pos)
+
+        // Check for keywords (case-insensitive), but only if followed by whitespace/end/paren/bracket
+        // and not containing dots or colons (which would make it an attribute path)
+        val lower = word.lowercase()
+        if (!word.contains('.') && !word.contains(':') && KEYWORD_MAP.containsKey(lower)) {
+            when (lower) {
+                "true" -> tokens.add(Token(TokenType.BOOLEAN_VALUE, "true", start))
+                "false" -> tokens.add(Token(TokenType.BOOLEAN_VALUE, "false", start))
+                "null" -> tokens.add(Token(TokenType.NULL_VALUE, "null", start))
+                else -> tokens.add(Token(KEYWORD_MAP.getValue(lower), word, start))
+            }
+        } else if (lower == "true" || lower == "false") {
+            tokens.add(Token(TokenType.BOOLEAN_VALUE, lower, start))
+        } else if (lower == "null") {
+            tokens.add(Token(TokenType.NULL_VALUE, "null", start))
+        } else {
+            tokens.add(Token(TokenType.ATTR_PATH, word, start))
+        }
+    }
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/lexer/Token.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/lexer/Token.kt
@@ -1,0 +1,12 @@
+package com.marcosbarbero.scim2.core.filter.lexer
+
+enum class TokenType {
+    ATTR_PATH,
+    STRING_VALUE, NUMBER_VALUE, BOOLEAN_VALUE, NULL_VALUE,
+    OP_EQ, OP_NE, OP_CO, OP_SW, OP_EW, OP_GT, OP_GE, OP_LT, OP_LE, OP_PR,
+    OP_AND, OP_OR, OP_NOT,
+    LPAREN, RPAREN, LBRACKET, RBRACKET,
+    EOF
+}
+
+data class Token(val type: TokenType, val value: String, val position: Int)

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/parser/FilterParser.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/parser/FilterParser.kt
@@ -1,0 +1,200 @@
+package com.marcosbarbero.scim2.core.filter.parser
+
+import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
+import com.marcosbarbero.scim2.core.filter.ast.AttributeExpression
+import com.marcosbarbero.scim2.core.filter.ast.AttributePath
+import com.marcosbarbero.scim2.core.filter.ast.ComparisonOperator
+import com.marcosbarbero.scim2.core.filter.ast.FilterNode
+import com.marcosbarbero.scim2.core.filter.ast.LogicalExpression
+import com.marcosbarbero.scim2.core.filter.ast.LogicalOperator
+import com.marcosbarbero.scim2.core.filter.ast.NotExpression
+import com.marcosbarbero.scim2.core.filter.ast.PresentExpression
+import com.marcosbarbero.scim2.core.filter.ast.ScimValue
+import com.marcosbarbero.scim2.core.filter.ast.ValuePathExpression
+import com.marcosbarbero.scim2.core.filter.lexer.FilterLexer
+import com.marcosbarbero.scim2.core.filter.lexer.Token
+import com.marcosbarbero.scim2.core.filter.lexer.TokenType
+
+object FilterParser {
+
+    fun parse(filter: String): FilterNode {
+        if (filter.isBlank()) {
+            throw InvalidFilterException("Filter expression is empty at position 0")
+        }
+        val tokens = FilterLexer(filter).tokenize()
+        val parser = Parser(tokens)
+        val node = parser.parseOrExpression()
+        parser.expect(TokenType.EOF, "Unexpected token after filter expression")
+        return node
+    }
+
+    internal class Parser(private val tokens: List<Token>) {
+        private var pos = 0
+
+        private fun current(): Token = tokens[pos]
+
+        private fun advance(): Token {
+            val token = tokens[pos]
+            if (pos < tokens.size - 1) pos++
+            return token
+        }
+
+        private fun peek(): TokenType = current().type
+
+        fun expect(type: TokenType, message: String): Token {
+            if (peek() != type) {
+                throw InvalidFilterException("$message at position ${current().position}")
+            }
+            return advance()
+        }
+
+        fun parseOrExpression(): FilterNode {
+            var left = parseAndExpression()
+            while (peek() == TokenType.OP_OR) {
+                advance()
+                val right = parseAndExpression()
+                left = LogicalExpression(LogicalOperator.OR, left, right)
+            }
+            return left
+        }
+
+        private fun parseAndExpression(): FilterNode {
+            var left = parseNotExpression()
+            while (peek() == TokenType.OP_AND) {
+                advance()
+                val right = parseNotExpression()
+                left = LogicalExpression(LogicalOperator.AND, left, right)
+            }
+            return left
+        }
+
+        private fun parseNotExpression(): FilterNode {
+            if (peek() == TokenType.OP_NOT) {
+                advance()
+                val operand = parseNotExpression()
+                return NotExpression(operand)
+            }
+            return parsePrimaryExpression()
+        }
+
+        private fun parsePrimaryExpression(): FilterNode {
+            if (peek() == TokenType.LPAREN) {
+                advance()
+                val expr = parseOrExpression()
+                expect(TokenType.RPAREN, "Expected ')' to close grouping")
+                return expr
+            }
+            return parseAttrExpression()
+        }
+
+        private fun parseAttrExpression(): FilterNode {
+            val pathToken = expect(TokenType.ATTR_PATH, "Expected attribute path")
+            val path = parseAttributePath(pathToken.value)
+
+            // Check for value path: attr[filter]
+            if (peek() == TokenType.LBRACKET) {
+                advance()
+                val innerFilter = parseOrExpression()
+                expect(TokenType.RBRACKET, "Expected ']' to close value path filter")
+
+                // Check for .subAttr after ]
+                var subAttr: String? = null
+                if (peek() == TokenType.ATTR_PATH && current().value.startsWith(".")) {
+                    subAttr = advance().value.removePrefix(".")
+                }
+                return ValuePathExpression(pathToken.value, innerFilter, subAttr)
+            }
+
+            // Check for presence
+            if (peek() == TokenType.OP_PR) {
+                advance()
+                return PresentExpression(path)
+            }
+
+            // Must be comparison
+            val operator = parseComparisonOperator()
+            val value = parseValue()
+            return AttributeExpression(path, operator, value)
+        }
+
+        private fun parseAttributePath(raw: String): AttributePath {
+            // Check for URN prefix: urn:...:attrName or urn:...:attrName.subAttr
+            if (raw.startsWith("urn:")) {
+                val lastColon = raw.lastIndexOf(':')
+                val schemaUri = raw.substring(0, lastColon)
+                val remainder = raw.substring(lastColon + 1)
+                val dotIdx = remainder.indexOf('.')
+                return if (dotIdx >= 0) {
+                    AttributePath(
+                        schemaUri = schemaUri,
+                        attributeName = remainder.substring(0, dotIdx),
+                        subAttribute = remainder.substring(dotIdx + 1)
+                    )
+                } else {
+                    AttributePath(schemaUri = schemaUri, attributeName = remainder)
+                }
+            }
+
+            // Simple or dotted path
+            val dotIdx = raw.indexOf('.')
+            return if (dotIdx >= 0) {
+                AttributePath(
+                    attributeName = raw.substring(0, dotIdx),
+                    subAttribute = raw.substring(dotIdx + 1)
+                )
+            } else {
+                AttributePath(attributeName = raw)
+            }
+        }
+
+        private fun parseComparisonOperator(): ComparisonOperator {
+            val token = current()
+            val op = when (token.type) {
+                TokenType.OP_EQ -> ComparisonOperator.EQ
+                TokenType.OP_NE -> ComparisonOperator.NE
+                TokenType.OP_CO -> ComparisonOperator.CO
+                TokenType.OP_SW -> ComparisonOperator.SW
+                TokenType.OP_EW -> ComparisonOperator.EW
+                TokenType.OP_GT -> ComparisonOperator.GT
+                TokenType.OP_GE -> ComparisonOperator.GE
+                TokenType.OP_LT -> ComparisonOperator.LT
+                TokenType.OP_LE -> ComparisonOperator.LE
+                else -> throw InvalidFilterException(
+                    "Expected comparison operator but found '${token.value}' at position ${token.position}"
+                )
+            }
+            advance()
+            return op
+        }
+
+        private fun parseValue(): ScimValue {
+            val token = current()
+            return when (token.type) {
+                TokenType.STRING_VALUE -> {
+                    advance()
+                    ScimValue.StringValue(token.value)
+                }
+                TokenType.NUMBER_VALUE -> {
+                    advance()
+                    val num = if (token.value.contains('.')) {
+                        token.value.toDouble()
+                    } else {
+                        token.value.toLong()
+                    }
+                    ScimValue.NumberValue(num)
+                }
+                TokenType.BOOLEAN_VALUE -> {
+                    advance()
+                    ScimValue.BooleanValue(token.value.toBoolean())
+                }
+                TokenType.NULL_VALUE -> {
+                    advance()
+                    ScimValue.NullValue
+                }
+                else -> throw InvalidFilterException(
+                    "Expected value but found '${token.value}' at position ${token.position}"
+                )
+            }
+        }
+    }
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/parser/PathParser.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/parser/PathParser.kt
@@ -1,0 +1,60 @@
+package com.marcosbarbero.scim2.core.filter.parser
+
+import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
+import com.marcosbarbero.scim2.core.filter.ast.FilterNode
+import com.marcosbarbero.scim2.core.filter.lexer.FilterLexer
+import com.marcosbarbero.scim2.core.filter.lexer.TokenType
+
+sealed class PathNode {
+    data class SimplePath(val attributeName: String, val subAttribute: String? = null) : PathNode()
+    data class FilteredPath(val attributeName: String, val filter: FilterNode, val subAttribute: String? = null) : PathNode()
+}
+
+object PathParser {
+
+    fun parse(path: String): PathNode {
+        if (path.isBlank()) {
+            throw InvalidFilterException("Path expression is empty at position 0")
+        }
+
+        val tokens = FilterLexer(path).tokenize()
+        val attrToken = tokens[0]
+        if (attrToken.type != TokenType.ATTR_PATH) {
+            throw InvalidFilterException("Expected attribute path at position ${attrToken.position}")
+        }
+
+        // Check for bracket filter: attr[filter]
+        if (tokens.size > 1 && tokens[1].type == TokenType.LBRACKET) {
+            val attrName = attrToken.value
+            // Re-parse the bracket content as a filter
+            val bracketStart = path.indexOf('[')
+            val bracketEnd = path.lastIndexOf(']')
+            if (bracketEnd < 0) {
+                throw InvalidFilterException("Unclosed bracket at position $bracketStart")
+            }
+            val filterStr = path.substring(bracketStart + 1, bracketEnd)
+            val filter = FilterParser.parse(filterStr)
+
+            // Check for .subAttr after ]
+            val afterBracket = path.substring(bracketEnd + 1)
+            val subAttr = if (afterBracket.startsWith(".") && afterBracket.length > 1) {
+                afterBracket.substring(1)
+            } else {
+                null
+            }
+
+            return PathNode.FilteredPath(attrName, filter, subAttr)
+        }
+
+        // Simple path: attr or attr.subAttr
+        val dotIdx = attrToken.value.indexOf('.')
+        return if (dotIdx >= 0) {
+            PathNode.SimplePath(
+                attributeName = attrToken.value.substring(0, dotIdx),
+                subAttribute = attrToken.value.substring(dotIdx + 1)
+            )
+        } else {
+            PathNode.SimplePath(attributeName = attrToken.value)
+        }
+    }
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToPredicateVisitor.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToPredicateVisitor.kt
@@ -1,0 +1,121 @@
+package com.marcosbarbero.scim2.core.filter.visitor
+
+import com.marcosbarbero.scim2.core.filter.ast.AttributeExpression
+import com.marcosbarbero.scim2.core.filter.ast.ComparisonOperator
+import com.marcosbarbero.scim2.core.filter.ast.LogicalExpression
+import com.marcosbarbero.scim2.core.filter.ast.LogicalOperator
+import com.marcosbarbero.scim2.core.filter.ast.NotExpression
+import com.marcosbarbero.scim2.core.filter.ast.PresentExpression
+import com.marcosbarbero.scim2.core.filter.ast.ScimValue
+import com.marcosbarbero.scim2.core.filter.ast.ValuePathExpression
+
+class FilterToPredicateVisitor : FilterVisitor<(Map<String, Any?>) -> Boolean> {
+
+    override fun visit(node: AttributeExpression): (Map<String, Any?>) -> Boolean = { data ->
+        val actual = resolvePath(data, node.path.toFullPath())
+        compareValues(actual, node.operator, node.value)
+    }
+
+    override fun visit(node: PresentExpression): (Map<String, Any?>) -> Boolean = { data ->
+        val actual = resolvePath(data, node.path.toFullPath())
+        actual != null
+    }
+
+    override fun visit(node: LogicalExpression): (Map<String, Any?>) -> Boolean = { data ->
+        when (node.operator) {
+            LogicalOperator.AND -> visit(node.left)(data) && visit(node.right)(data)
+            LogicalOperator.OR -> visit(node.left)(data) || visit(node.right)(data)
+        }
+    }
+
+    override fun visit(node: NotExpression): (Map<String, Any?>) -> Boolean = { data ->
+        !visit(node.operand)(data)
+    }
+
+    override fun visit(node: ValuePathExpression): (Map<String, Any?>) -> Boolean = { data ->
+        val collection = data[node.attributePath]
+        if (collection is List<*>) {
+            val innerPredicate = visit(node.filter)
+            val matchingItems = collection.filterIsInstance<Map<String, Any?>>().filter { innerPredicate(it) }
+            if (node.subAttribute != null) {
+                // There's a sub-attribute + outer comparison - but as a standalone value path,
+                // just check that matching items exist with that sub-attribute
+                matchingItems.any { it.containsKey(node.subAttribute) }
+            } else {
+                matchingItems.isNotEmpty()
+            }
+        } else {
+            false
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun resolvePath(data: Map<String, Any?>, path: String): Any? {
+        val parts = path.split(".")
+        var current: Any? = data
+        for (part in parts) {
+            if (current is Map<*, *>) {
+                current = (current as Map<String, Any?>)[part]
+            } else {
+                return null
+            }
+        }
+        return current
+    }
+
+    private fun compareValues(actual: Any?, operator: ComparisonOperator, expected: ScimValue): Boolean {
+        // Handle null comparisons
+        if (expected is ScimValue.NullValue) {
+            return when (operator) {
+                ComparisonOperator.EQ -> actual == null
+                ComparisonOperator.NE -> actual != null
+                else -> false
+            }
+        }
+
+        if (actual == null) return false
+
+        return when (operator) {
+            ComparisonOperator.EQ -> equalsValue(actual, expected)
+            ComparisonOperator.NE -> !equalsValue(actual, expected)
+            ComparisonOperator.CO -> stringOp(actual, expected) { a, e -> a.contains(e, ignoreCase = true) }
+            ComparisonOperator.SW -> stringOp(actual, expected) { a, e -> a.startsWith(e, ignoreCase = true) }
+            ComparisonOperator.EW -> stringOp(actual, expected) { a, e -> a.endsWith(e, ignoreCase = true) }
+            ComparisonOperator.GT -> numericCompare(actual, expected) { it > 0 }
+            ComparisonOperator.GE -> numericCompare(actual, expected) { it >= 0 }
+            ComparisonOperator.LT -> numericCompare(actual, expected) { it < 0 }
+            ComparisonOperator.LE -> numericCompare(actual, expected) { it <= 0 }
+        }
+    }
+
+    private fun equalsValue(actual: Any?, expected: ScimValue): Boolean = when (expected) {
+        is ScimValue.StringValue -> actual.toString() == expected.value
+        is ScimValue.NumberValue -> toComparable(actual) == toComparable(expected.value)
+        is ScimValue.BooleanValue -> actual == expected.value
+        is ScimValue.NullValue -> actual == null
+    }
+
+    private fun stringOp(actual: Any?, expected: ScimValue, op: (String, String) -> Boolean): Boolean {
+        if (expected !is ScimValue.StringValue) return false
+        return op(actual.toString(), expected.value)
+    }
+
+    private fun numericCompare(actual: Any?, expected: ScimValue, check: (Int) -> Boolean): Boolean {
+        if (expected !is ScimValue.NumberValue) return false
+        val a = toComparable(actual) ?: return false
+        val b = toComparable(expected.value) ?: return false
+        @Suppress("UNCHECKED_CAST")
+        return check((a as Comparable<Any>).compareTo(b))
+    }
+
+    private fun toComparable(value: Any?): Comparable<*>? = when (value) {
+        is Int -> value.toLong()
+        is Long -> value
+        is Float -> value.toDouble()
+        is Double -> value
+        is Number -> value.toDouble()
+        is String -> value
+        is Boolean -> value
+        else -> null
+    }
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToStringVisitor.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToStringVisitor.kt
@@ -1,0 +1,63 @@
+package com.marcosbarbero.scim2.core.filter.visitor
+
+import com.marcosbarbero.scim2.core.filter.ast.AttributeExpression
+import com.marcosbarbero.scim2.core.filter.ast.ComparisonOperator
+import com.marcosbarbero.scim2.core.filter.ast.LogicalExpression
+import com.marcosbarbero.scim2.core.filter.ast.LogicalOperator
+import com.marcosbarbero.scim2.core.filter.ast.NotExpression
+import com.marcosbarbero.scim2.core.filter.ast.PresentExpression
+import com.marcosbarbero.scim2.core.filter.ast.ScimValue
+import com.marcosbarbero.scim2.core.filter.ast.ValuePathExpression
+
+class FilterToStringVisitor : FilterVisitor<String> {
+
+    override fun visit(node: AttributeExpression): String {
+        val path = node.path.toFullPath()
+        val op = node.operator.name.lowercase()
+        val value = formatValue(node.value)
+        return "$path $op $value"
+    }
+
+    override fun visit(node: PresentExpression): String {
+        return "${node.path.toFullPath()} pr"
+    }
+
+    override fun visit(node: LogicalExpression): String {
+        val left = visitWithPrecedence(node.left, node.operator)
+        val right = visitWithPrecedence(node.right, node.operator, isRight = true)
+        val op = node.operator.name.lowercase()
+        return "$left $op $right"
+    }
+
+    override fun visit(node: NotExpression): String {
+        val operand = visit(node.operand)
+        return "not $operand"
+    }
+
+    override fun visit(node: ValuePathExpression): String {
+        val inner = visit(node.filter)
+        val sub = if (node.subAttribute != null) ".${node.subAttribute}" else ""
+        return "${node.attributePath}[$inner]$sub"
+    }
+
+    private fun visitWithPrecedence(node: com.marcosbarbero.scim2.core.filter.ast.FilterNode, parentOp: LogicalOperator, isRight: Boolean = false): String {
+        if (node is LogicalExpression && node.operator == LogicalOperator.OR && parentOp == LogicalOperator.AND) {
+            return "(${visit(node)})"
+        }
+        return visit(node)
+    }
+
+    private fun formatValue(value: ScimValue): String = when (value) {
+        is ScimValue.StringValue -> "\"${value.value}\""
+        is ScimValue.NumberValue -> {
+            if (value.value is Double || value.value is Float) {
+                val d = value.value.toDouble()
+                if (d == d.toLong().toDouble()) d.toLong().toString() else d.toString()
+            } else {
+                value.value.toString()
+            }
+        }
+        is ScimValue.BooleanValue -> value.value.toString()
+        is ScimValue.NullValue -> "null"
+    }
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterVisitor.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterVisitor.kt
@@ -1,0 +1,24 @@
+package com.marcosbarbero.scim2.core.filter.visitor
+
+import com.marcosbarbero.scim2.core.filter.ast.AttributeExpression
+import com.marcosbarbero.scim2.core.filter.ast.FilterNode
+import com.marcosbarbero.scim2.core.filter.ast.LogicalExpression
+import com.marcosbarbero.scim2.core.filter.ast.NotExpression
+import com.marcosbarbero.scim2.core.filter.ast.PresentExpression
+import com.marcosbarbero.scim2.core.filter.ast.ValuePathExpression
+
+interface FilterVisitor<T> {
+    fun visit(node: AttributeExpression): T
+    fun visit(node: PresentExpression): T
+    fun visit(node: LogicalExpression): T
+    fun visit(node: NotExpression): T
+    fun visit(node: ValuePathExpression): T
+
+    fun visit(node: FilterNode): T = when (node) {
+        is AttributeExpression -> visit(node)
+        is PresentExpression -> visit(node)
+        is LogicalExpression -> visit(node)
+        is NotExpression -> visit(node)
+        is ValuePathExpression -> visit(node)
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/lexer/FilterLexerTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/lexer/FilterLexerTest.kt
@@ -1,0 +1,241 @@
+package com.marcosbarbero.scim2.core.filter.lexer
+
+import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FilterLexerTest {
+
+    private fun tokenize(input: String): List<Token> = FilterLexer(input).tokenize()
+
+    private fun tokenTypes(input: String): List<TokenType> =
+        tokenize(input).map { it.type }.dropLast(1) // drop EOF
+
+    @Nested
+    inner class AttributePathTokens {
+
+        @Test
+        fun `should tokenize simple attribute`() {
+            val tokens = tokenize("userName")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.ATTR_PATH
+            tokens[0].value shouldBe "userName"
+            tokens[1].type shouldBe TokenType.EOF
+        }
+
+        @Test
+        fun `should tokenize dotted attribute path`() {
+            val tokens = tokenize("name.familyName")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.ATTR_PATH
+            tokens[0].value shouldBe "name.familyName"
+        }
+
+        @Test
+        fun `should tokenize URN-prefixed attribute path`() {
+            val tokens = tokenize("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.ATTR_PATH
+            tokens[0].value shouldBe "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department"
+        }
+    }
+
+    @Nested
+    inner class LiteralTokens {
+
+        @Test
+        fun `should tokenize quoted string`() {
+            val tokens = tokenize("\"hello world\"")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.STRING_VALUE
+            tokens[0].value shouldBe "hello world"
+        }
+
+        @Test
+        fun `should tokenize string with escaped quote`() {
+            val tokens = tokenize("\"hello \\\"world\\\"\"")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.STRING_VALUE
+            tokens[0].value shouldBe "hello \"world\""
+        }
+
+        @Test
+        fun `should tokenize string with escaped backslash`() {
+            val tokens = tokenize("\"path\\\\to\"")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.STRING_VALUE
+            tokens[0].value shouldBe "path\\to"
+        }
+
+        @Test
+        fun `should tokenize integer number`() {
+            val tokens = tokenize("42")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.NUMBER_VALUE
+            tokens[0].value shouldBe "42"
+        }
+
+        @Test
+        fun `should tokenize decimal number`() {
+            val tokens = tokenize("3.14")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.NUMBER_VALUE
+            tokens[0].value shouldBe "3.14"
+        }
+
+        @Test
+        fun `should tokenize negative number`() {
+            val tokens = tokenize("-99")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.NUMBER_VALUE
+            tokens[0].value shouldBe "-99"
+        }
+
+        @Test
+        fun `should tokenize boolean true`() {
+            val tokens = tokenize("true")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.BOOLEAN_VALUE
+            tokens[0].value shouldBe "true"
+        }
+
+        @Test
+        fun `should tokenize boolean false`() {
+            val tokens = tokenize("false")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.BOOLEAN_VALUE
+            tokens[0].value shouldBe "false"
+        }
+
+        @Test
+        fun `should tokenize null`() {
+            val tokens = tokenize("null")
+            tokens shouldHaveSize 2
+            tokens[0].type shouldBe TokenType.NULL_VALUE
+            tokens[0].value shouldBe "null"
+        }
+    }
+
+    @Nested
+    inner class ComparisonOperatorTokens {
+
+        @Test
+        fun `should tokenize all comparison operators case-insensitively`() {
+            val operators = mapOf(
+                "eq" to TokenType.OP_EQ,
+                "NE" to TokenType.OP_NE,
+                "Co" to TokenType.OP_CO,
+                "sw" to TokenType.OP_SW,
+                "EW" to TokenType.OP_EW,
+                "gt" to TokenType.OP_GT,
+                "GE" to TokenType.OP_GE,
+                "lt" to TokenType.OP_LT,
+                "LE" to TokenType.OP_LE,
+                "pr" to TokenType.OP_PR
+            )
+            for ((op, expectedType) in operators) {
+                val tokens = tokenize("attr $op")
+                tokens[1].type shouldBe expectedType
+            }
+        }
+    }
+
+    @Nested
+    inner class LogicalOperatorTokens {
+
+        @Test
+        fun `should tokenize and`() {
+            tokenTypes("a eq \"1\" and b eq \"2\"") shouldBe listOf(
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE,
+                TokenType.OP_AND,
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE
+            )
+        }
+
+        @Test
+        fun `should tokenize or`() {
+            tokenTypes("a eq \"1\" or b eq \"2\"") shouldBe listOf(
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE,
+                TokenType.OP_OR,
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE
+            )
+        }
+
+        @Test
+        fun `should tokenize not`() {
+            tokenTypes("not a eq \"1\"") shouldBe listOf(
+                TokenType.OP_NOT, TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE
+            )
+        }
+    }
+
+    @Nested
+    inner class GroupingTokens {
+
+        @Test
+        fun `should tokenize parentheses`() {
+            tokenTypes("(a eq \"1\")") shouldBe listOf(
+                TokenType.LPAREN, TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE, TokenType.RPAREN
+            )
+        }
+
+        @Test
+        fun `should tokenize brackets`() {
+            tokenTypes("emails[type eq \"work\"]") shouldBe listOf(
+                TokenType.ATTR_PATH, TokenType.LBRACKET,
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE,
+                TokenType.RBRACKET
+            )
+        }
+    }
+
+    @Nested
+    inner class ComplexFilters {
+
+        @Test
+        fun `should tokenize complex filter with multiple operators`() {
+            tokenTypes("userName eq \"john\" and active eq true or title pr") shouldBe listOf(
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE,
+                TokenType.OP_AND,
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.BOOLEAN_VALUE,
+                TokenType.OP_OR,
+                TokenType.ATTR_PATH, TokenType.OP_PR
+            )
+        }
+
+        @Test
+        fun `should tokenize value path filter`() {
+            tokenTypes("emails[type eq \"work\" and value co \"@example.com\"]") shouldBe listOf(
+                TokenType.ATTR_PATH, TokenType.LBRACKET,
+                TokenType.ATTR_PATH, TokenType.OP_EQ, TokenType.STRING_VALUE,
+                TokenType.OP_AND,
+                TokenType.ATTR_PATH, TokenType.OP_CO, TokenType.STRING_VALUE,
+                TokenType.RBRACKET
+            )
+        }
+    }
+
+    @Nested
+    inner class ErrorHandling {
+
+        @Test
+        fun `should report error with position for unclosed string`() {
+            val ex = shouldThrow<InvalidFilterException> {
+                tokenize("\"unclosed string")
+            }
+            ex.detail shouldContain "position"
+        }
+
+        @Test
+        fun `should report error for unexpected character`() {
+            val ex = shouldThrow<InvalidFilterException> {
+                tokenize("@invalid")
+            }
+            ex.detail shouldContain "position"
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/parser/FilterParserTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/parser/FilterParserTest.kt
@@ -1,0 +1,264 @@
+package com.marcosbarbero.scim2.core.filter.parser
+
+import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
+import com.marcosbarbero.scim2.core.filter.ast.AttributeExpression
+import com.marcosbarbero.scim2.core.filter.ast.AttributePath
+import com.marcosbarbero.scim2.core.filter.ast.ComparisonOperator
+import com.marcosbarbero.scim2.core.filter.ast.FilterNode
+import com.marcosbarbero.scim2.core.filter.ast.LogicalExpression
+import com.marcosbarbero.scim2.core.filter.ast.LogicalOperator
+import com.marcosbarbero.scim2.core.filter.ast.NotExpression
+import com.marcosbarbero.scim2.core.filter.ast.PresentExpression
+import com.marcosbarbero.scim2.core.filter.ast.ScimValue
+import com.marcosbarbero.scim2.core.filter.ast.ValuePathExpression
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FilterParserTest {
+
+    private fun parse(filter: String): FilterNode = FilterParser.parse(filter)
+
+    @Nested
+    inner class SimpleComparisons {
+
+        @Test
+        fun `should parse string equality`() {
+            val node = parse("userName eq \"john\"")
+            node.shouldBeInstanceOf<AttributeExpression>()
+            node.path shouldBe AttributePath(attributeName = "userName")
+            node.operator shouldBe ComparisonOperator.EQ
+            node.value shouldBe ScimValue.StringValue("john")
+        }
+
+        @Test
+        fun `should parse all comparison operators`() {
+            val ops = mapOf(
+                "eq" to ComparisonOperator.EQ,
+                "ne" to ComparisonOperator.NE,
+                "co" to ComparisonOperator.CO,
+                "sw" to ComparisonOperator.SW,
+                "ew" to ComparisonOperator.EW,
+                "gt" to ComparisonOperator.GT,
+                "ge" to ComparisonOperator.GE,
+                "lt" to ComparisonOperator.LT,
+                "le" to ComparisonOperator.LE
+            )
+            for ((op, expected) in ops) {
+                val node = parse("attr $op \"val\"")
+                node.shouldBeInstanceOf<AttributeExpression>()
+                node.operator shouldBe expected
+            }
+        }
+
+        @Test
+        fun `should parse number comparison`() {
+            val node = parse("age gt 30")
+            node.shouldBeInstanceOf<AttributeExpression>()
+            node.value.shouldBeInstanceOf<ScimValue.NumberValue>()
+            (node.value as ScimValue.NumberValue).value shouldBe 30
+        }
+
+        @Test
+        fun `should parse decimal number comparison`() {
+            val node = parse("score ge 3.14")
+            node.shouldBeInstanceOf<AttributeExpression>()
+            val value = node.value as ScimValue.NumberValue
+            value.value shouldBe 3.14
+        }
+
+        @Test
+        fun `should parse boolean comparison`() {
+            val node = parse("active eq true")
+            node.shouldBeInstanceOf<AttributeExpression>()
+            node.value shouldBe ScimValue.BooleanValue(true)
+        }
+
+        @Test
+        fun `should parse null comparison`() {
+            val node = parse("title eq null")
+            node.shouldBeInstanceOf<AttributeExpression>()
+            node.value shouldBe ScimValue.NullValue
+        }
+
+        @Test
+        fun `should parse dotted attribute path`() {
+            val node = parse("name.familyName eq \"Jensen\"")
+            node.shouldBeInstanceOf<AttributeExpression>()
+            node.path shouldBe AttributePath(attributeName = "name", subAttribute = "familyName")
+        }
+    }
+
+    @Nested
+    inner class PresenceFilter {
+
+        @Test
+        fun `should parse presence filter`() {
+            val node = parse("title pr")
+            node.shouldBeInstanceOf<PresentExpression>()
+            node.path shouldBe AttributePath(attributeName = "title")
+        }
+
+        @Test
+        fun `should parse presence filter with dotted path`() {
+            val node = parse("name.familyName pr")
+            node.shouldBeInstanceOf<PresentExpression>()
+            node.path shouldBe AttributePath(attributeName = "name", subAttribute = "familyName")
+        }
+    }
+
+    @Nested
+    inner class LogicalOperators {
+
+        @Test
+        fun `should parse AND expression`() {
+            val node = parse("userName eq \"john\" and active eq true")
+            node.shouldBeInstanceOf<LogicalExpression>()
+            node.operator shouldBe LogicalOperator.AND
+            node.left.shouldBeInstanceOf<AttributeExpression>()
+            node.right.shouldBeInstanceOf<AttributeExpression>()
+        }
+
+        @Test
+        fun `should parse OR expression`() {
+            val node = parse("userName eq \"john\" or userName eq \"jane\"")
+            node.shouldBeInstanceOf<LogicalExpression>()
+            node.operator shouldBe LogicalOperator.OR
+        }
+
+        @Test
+        fun `should handle AND higher precedence than OR`() {
+            // a eq "1" or b eq "2" and c eq "3" → OR(a=1, AND(b=2, c=3))
+            val node = parse("a eq \"1\" or b eq \"2\" and c eq \"3\"")
+            node.shouldBeInstanceOf<LogicalExpression>()
+            node.operator shouldBe LogicalOperator.OR
+            node.left.shouldBeInstanceOf<AttributeExpression>()
+            (node.left as AttributeExpression).path.attributeName shouldBe "a"
+            node.right.shouldBeInstanceOf<LogicalExpression>()
+            (node.right as LogicalExpression).operator shouldBe LogicalOperator.AND
+        }
+
+        @Test
+        fun `should parse NOT expression`() {
+            val node = parse("not userName eq \"john\"")
+            node.shouldBeInstanceOf<NotExpression>()
+            node.operand.shouldBeInstanceOf<AttributeExpression>()
+        }
+
+        @Test
+        fun `should parse NOT with higher precedence than AND`() {
+            // not a eq "1" and b eq "2" → AND(NOT(a=1), b=2)
+            val node = parse("not a eq \"1\" and b eq \"2\"")
+            node.shouldBeInstanceOf<LogicalExpression>()
+            node.operator shouldBe LogicalOperator.AND
+            node.left.shouldBeInstanceOf<NotExpression>()
+            node.right.shouldBeInstanceOf<AttributeExpression>()
+        }
+    }
+
+    @Nested
+    inner class Grouping {
+
+        @Test
+        fun `should parse parenthesized expression`() {
+            val node = parse("(userName eq \"john\")")
+            node.shouldBeInstanceOf<AttributeExpression>()
+        }
+
+        @Test
+        fun `should override precedence with parentheses`() {
+            // (a eq "1" or b eq "2") and c eq "3" → AND(OR(a=1, b=2), c=3)
+            val node = parse("(a eq \"1\" or b eq \"2\") and c eq \"3\"")
+            node.shouldBeInstanceOf<LogicalExpression>()
+            node.operator shouldBe LogicalOperator.AND
+            node.left.shouldBeInstanceOf<LogicalExpression>()
+            (node.left as LogicalExpression).operator shouldBe LogicalOperator.OR
+        }
+    }
+
+    @Nested
+    inner class ValuePathFilters {
+
+        @Test
+        fun `should parse simple value path`() {
+            val node = parse("emails[type eq \"work\"]")
+            node.shouldBeInstanceOf<ValuePathExpression>()
+            node.attributePath shouldBe "emails"
+            node.filter.shouldBeInstanceOf<AttributeExpression>()
+            node.subAttribute shouldBe null
+        }
+
+        @Test
+        fun `should parse value path with sub-attribute`() {
+            val node = parse("emails[type eq \"work\"].value")
+            node.shouldBeInstanceOf<ValuePathExpression>()
+            node.attributePath shouldBe "emails"
+            node.subAttribute shouldBe "value"
+        }
+
+        @Test
+        fun `should parse value path with complex inner filter`() {
+            val node = parse("emails[type eq \"work\" and value co \"@example.com\"]")
+            node.shouldBeInstanceOf<ValuePathExpression>()
+            node.filter.shouldBeInstanceOf<LogicalExpression>()
+        }
+    }
+
+    @Nested
+    inner class UrnPrefixedPaths {
+
+        @Test
+        fun `should parse URN-prefixed attribute path`() {
+            val node = parse("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department eq \"Engineering\"")
+            node.shouldBeInstanceOf<AttributeExpression>()
+            node.path.schemaUri shouldBe "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            node.path.attributeName shouldBe "department"
+        }
+    }
+
+    @Nested
+    inner class ErrorCases {
+
+        @Test
+        fun `should throw on missing comparison value`() {
+            val ex = shouldThrow<InvalidFilterException> {
+                parse("userName eq")
+            }
+            ex.detail shouldContain "position"
+        }
+
+        @Test
+        fun `should throw on unclosed parenthesis`() {
+            val ex = shouldThrow<InvalidFilterException> {
+                parse("(userName eq \"john\"")
+            }
+            ex.detail shouldContain "position"
+        }
+
+        @Test
+        fun `should throw on invalid operator`() {
+            val ex = shouldThrow<InvalidFilterException> {
+                parse("userName xx \"john\"")
+            }
+            ex.detail shouldContain "position"
+        }
+
+        @Test
+        fun `should throw on empty filter`() {
+            shouldThrow<InvalidFilterException> {
+                parse("")
+            }
+        }
+
+        @Test
+        fun `should throw on unclosed bracket`() {
+            val ex = shouldThrow<InvalidFilterException> {
+                parse("emails[type eq \"work\"")
+            }
+            ex.detail shouldContain "position"
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/parser/PathParserTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/parser/PathParserTest.kt
@@ -1,0 +1,51 @@
+package com.marcosbarbero.scim2.core.filter.parser
+
+import com.marcosbarbero.scim2.core.filter.ast.AttributeExpression
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PathParserTest {
+
+    @Nested
+    inner class SimplePathParsing {
+
+        @Test
+        fun `should parse simple attribute name`() {
+            val node = PathParser.parse("userName")
+            node.shouldBeInstanceOf<PathNode.SimplePath>()
+            node.attributeName shouldBe "userName"
+            node.subAttribute shouldBe null
+        }
+
+        @Test
+        fun `should parse dotted attribute path`() {
+            val node = PathParser.parse("name.familyName")
+            node.shouldBeInstanceOf<PathNode.SimplePath>()
+            node.attributeName shouldBe "name"
+            node.subAttribute shouldBe "familyName"
+        }
+    }
+
+    @Nested
+    inner class FilteredPathParsing {
+
+        @Test
+        fun `should parse filtered path`() {
+            val node = PathParser.parse("emails[type eq \"work\"]")
+            node.shouldBeInstanceOf<PathNode.FilteredPath>()
+            node.attributeName shouldBe "emails"
+            node.filter.shouldBeInstanceOf<AttributeExpression>()
+            node.subAttribute shouldBe null
+        }
+
+        @Test
+        fun `should parse filtered path with sub-attribute`() {
+            val node = PathParser.parse("emails[type eq \"work\"].value")
+            node.shouldBeInstanceOf<PathNode.FilteredPath>()
+            node.attributeName shouldBe "emails"
+            node.subAttribute shouldBe "value"
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToPredicateVisitorTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToPredicateVisitorTest.kt
@@ -1,0 +1,162 @@
+package com.marcosbarbero.scim2.core.filter.visitor
+
+import com.marcosbarbero.scim2.core.filter.parser.FilterParser
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FilterToPredicateVisitorTest {
+
+    private val visitor = FilterToPredicateVisitor()
+
+    private fun matches(filter: String, data: Map<String, Any?>): Boolean {
+        val node = FilterParser.parse(filter)
+        val predicate = visitor.visit(node)
+        return predicate(data)
+    }
+
+    private val sampleUser = mapOf<String, Any?>(
+        "userName" to "bjensen",
+        "active" to true,
+        "title" to "Tour Guide",
+        "age" to 30,
+        "name" to mapOf("familyName" to "Jensen", "givenName" to "Barbara"),
+        "emails" to listOf(
+            mapOf("type" to "work", "value" to "bjensen@example.com", "primary" to true),
+            mapOf("type" to "home", "value" to "babs@example.org", "primary" to false)
+        )
+    )
+
+    @Nested
+    inner class ComparisonOperators {
+
+        @Test
+        fun `eq should match equal string`() {
+            matches("userName eq \"bjensen\"", sampleUser) shouldBe true
+            matches("userName eq \"other\"", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `ne should match not equal`() {
+            matches("userName ne \"other\"", sampleUser) shouldBe true
+            matches("userName ne \"bjensen\"", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `co should match contains`() {
+            matches("userName co \"jensen\"", sampleUser) shouldBe true
+            matches("userName co \"xyz\"", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `sw should match starts with`() {
+            matches("userName sw \"bjen\"", sampleUser) shouldBe true
+            matches("userName sw \"xyz\"", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `ew should match ends with`() {
+            matches("userName ew \"ensen\"", sampleUser) shouldBe true
+            matches("userName ew \"xyz\"", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `gt should match greater than`() {
+            matches("age gt 25", sampleUser) shouldBe true
+            matches("age gt 30", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `ge should match greater than or equal`() {
+            matches("age ge 30", sampleUser) shouldBe true
+            matches("age ge 31", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `lt should match less than`() {
+            matches("age lt 35", sampleUser) shouldBe true
+            matches("age lt 30", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `le should match less than or equal`() {
+            matches("age le 30", sampleUser) shouldBe true
+            matches("age le 29", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `eq should match boolean`() {
+            matches("active eq true", sampleUser) shouldBe true
+            matches("active eq false", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `eq null should match missing attribute`() {
+            matches("missing eq null", sampleUser) shouldBe true
+            matches("userName eq null", sampleUser) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class PresenceOperator {
+
+        @Test
+        fun `pr should match present attribute`() {
+            matches("title pr", sampleUser) shouldBe true
+        }
+
+        @Test
+        fun `pr should not match absent attribute`() {
+            matches("missing pr", sampleUser) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class LogicalOperators {
+
+        @Test
+        fun `and should require both conditions`() {
+            matches("userName eq \"bjensen\" and active eq true", sampleUser) shouldBe true
+            matches("userName eq \"bjensen\" and active eq false", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `or should require at least one condition`() {
+            matches("userName eq \"bjensen\" or userName eq \"other\"", sampleUser) shouldBe true
+            matches("userName eq \"x\" or userName eq \"y\"", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `not should negate condition`() {
+            matches("not userName eq \"other\"", sampleUser) shouldBe true
+            matches("not userName eq \"bjensen\"", sampleUser) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class DottedPaths {
+
+        @Test
+        fun `should resolve dotted attribute path`() {
+            matches("name.familyName eq \"Jensen\"", sampleUser) shouldBe true
+            matches("name.familyName eq \"Smith\"", sampleUser) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class ValuePathFilters {
+
+        @Test
+        fun `should filter multi-valued attribute`() {
+            matches("emails[type eq \"work\"]", sampleUser) shouldBe true
+            matches("emails[type eq \"other\"]", sampleUser) shouldBe false
+        }
+
+        @Test
+        fun `should filter value path with sub-attribute`() {
+            // emails[type eq "work"].value - checks that a matching email has a value sub-attribute
+            matches("emails[type eq \"work\"].value", sampleUser) shouldBe true
+            matches("emails[type eq \"other\"].value", sampleUser) shouldBe false
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToStringVisitorTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToStringVisitorTest.kt
@@ -1,0 +1,88 @@
+package com.marcosbarbero.scim2.core.filter.visitor
+
+import com.marcosbarbero.scim2.core.filter.parser.FilterParser
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class FilterToStringVisitorTest {
+
+    private val visitor = FilterToStringVisitor()
+
+    private fun roundTrip(filter: String): String {
+        val node = FilterParser.parse(filter)
+        return visitor.visit(node)
+    }
+
+    @Test
+    fun `should round-trip simple equality`() {
+        roundTrip("userName eq \"john\"") shouldBe "userName eq \"john\""
+    }
+
+    @Test
+    fun `should round-trip presence`() {
+        roundTrip("title pr") shouldBe "title pr"
+    }
+
+    @Test
+    fun `should round-trip AND expression`() {
+        roundTrip("userName eq \"john\" and active eq true") shouldBe
+            "userName eq \"john\" and active eq true"
+    }
+
+    @Test
+    fun `should round-trip OR expression`() {
+        roundTrip("userName eq \"john\" or userName eq \"jane\"") shouldBe
+            "userName eq \"john\" or userName eq \"jane\""
+    }
+
+    @Test
+    fun `should round-trip NOT expression`() {
+        roundTrip("not userName eq \"john\"") shouldBe "not userName eq \"john\""
+    }
+
+    @Test
+    fun `should round-trip value path`() {
+        roundTrip("emails[type eq \"work\"]") shouldBe "emails[type eq \"work\"]"
+    }
+
+    @Test
+    fun `should round-trip value path with sub-attribute`() {
+        roundTrip("emails[type eq \"work\"].value") shouldBe "emails[type eq \"work\"].value"
+    }
+
+    @Test
+    fun `should round-trip number comparison`() {
+        roundTrip("age gt 30") shouldBe "age gt 30"
+    }
+
+    @Test
+    fun `should round-trip boolean comparison`() {
+        roundTrip("active eq true") shouldBe "active eq true"
+    }
+
+    @Test
+    fun `should round-trip null comparison`() {
+        roundTrip("title eq null") shouldBe "title eq null"
+    }
+
+    @Test
+    fun `should round-trip complex precedence`() {
+        // Parser produces OR(a=1, AND(b=2, c=3)), which serializes without extra parens
+        val result = roundTrip("a eq \"1\" or b eq \"2\" and c eq \"3\"")
+        result shouldBe "a eq \"1\" or b eq \"2\" and c eq \"3\""
+    }
+
+    @Test
+    fun `should round-trip dotted path`() {
+        roundTrip("name.familyName eq \"Jensen\"") shouldBe "name.familyName eq \"Jensen\""
+    }
+
+    @Test
+    fun `round-trip parse produces same AST`() {
+        val filter = "userName eq \"john\" and active eq true"
+        val ast1 = FilterParser.parse(filter)
+        val serialized = visitor.visit(ast1)
+        val ast2 = FilterParser.parse(serialized)
+        ast1 shouldBe ast2
+    }
+}


### PR DESCRIPTION
## Summary

- Implement a complete SCIM filter parser (RFC 7644 Section 3.4.2.2) with lexer, recursive descent parser, AST, path parser, and two visitors
- 83 new filter-specific tests (123 total in scim2-sdk-core), all passing
- TDD approach: tests written first

## Details

### Lexer (`filter/lexer/`)
- Tokenizes filter strings with support for quoted strings (with escaping), numbers, booleans, null
- Case-insensitive operator recognition (eq, ne, co, sw, ew, gt, ge, lt, le, pr, and, or, not)
- Attribute paths: simple (`userName`), dotted (`name.familyName`), URN-prefixed (`urn:...:department`)
- Error messages include character position

### AST (`filter/ast/`)
| Node Type | Description |
|-----------|-------------|
| `AttributeExpression` | `path op value` (e.g., `userName eq "john"`) |
| `PresentExpression` | `path pr` (e.g., `title pr`) |
| `LogicalExpression` | `left AND/OR right` |
| `NotExpression` | `NOT operand` |
| `ValuePathExpression` | `attr[filter].subAttr` (e.g., `emails[type eq "work"].value`) |

### Parser (`filter/parser/`)
- Recursive descent with correct precedence: NOT > AND > OR
- Parenthesized grouping overrides precedence
- Value path expressions with optional sub-attribute
- `PathParser` for PATCH operation paths (simple, dotted, filtered)

### Visitors (`filter/visitor/`)
- `FilterVisitor<T>` interface with sealed-class dispatch
- `FilterToStringVisitor` - AST to string serialization (round-trip verified)
- `FilterToPredicateVisitor` - evaluates filters against `Map<String, Any?>` for in-memory filtering

## Test plan

- [x] 83 filter tests: lexer tokens, parser AST structure, precedence, error cases, visitor round-trips, predicate evaluation
- [x] 123 total tests in scim2-sdk-core, all passing
- [x] Full reactor `mvn clean verify -B` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)