### PR TITLE
feat: Schema introspector, registry, and serialization SPI

### DIFF
--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaIntrospector.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaIntrospector.kt
@@ -77,7 +77,7 @@ class SchemaIntrospector {
 
         return SchemaAttribute(
             name = annotation?.name?.takeIf { it.isNotEmpty() } ?: property.name,
-            type = annotation?.type?.takeIf { it != AttributeType.STRING } ?: attrType,
+            type = if (annotation != null) annotation.type else attrType,
             multiValued = isMultiValued,
             description = annotation?.description ?: "",
             required = annotation?.required ?: false,

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaRegistry.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaRegistry.kt
@@ -36,19 +36,18 @@ class SchemaRegistry {
                 "Class ${resourceType.simpleName} must be annotated with @ScimResource"
             )
 
-        val existing = resourceTypes[rtAnnotation.name]
-            ?: throw IllegalStateException(
-                "Resource type ${rtAnnotation.name} must be registered before adding extensions"
-            )
-
         val extension = ResourceType.SchemaExtension(
             schema = extensionAnnotation.schema,
             required = false
         )
 
-        resourceTypes[existing.name] = existing.copy(
-            schemaExtensions = existing.schemaExtensions + extension
-        )
+        resourceTypes.compute(rtAnnotation.name) { _, existing ->
+            existing
+                ?: throw IllegalStateException(
+                    "Resource type ${rtAnnotation.name} must be registered before adding extensions"
+                )
+            existing.copy(schemaExtensions = existing.schemaExtensions + extension)
+        }
     }
 
     fun getSchema(uri: String): Schema? = schemas[uri]


### PR DESCRIPTION
## Summary

- Add **schema domain model**: `Schema`, `SchemaAttribute`, `ResourceType`, `ServiceProviderConfig` data classes in `domain/model/schema/`
- Add **`SchemaIntrospector`** that reads `@ScimResource`, `@ScimAttribute`, `@ScimExtension` annotations via Kotlin reflection to build `Schema` and `ResourceType` instances. Supports recursive sub-attribute introspection for complex types (Name, Address, etc.) and automatic type inference from Kotlin property types
- Add **`SchemaRegistry`** with thread-safe `ConcurrentHashMap` storage, supporting resource and extension registration, lookup by URI/name, and listing all registered schemas/types
- Add **`ScimSerializer` SPI interface** in `serialization/spi/` with `serialize`/`deserialize` (byte array) and `serializeToString`/`deserializeFromString` (String) methods
- Add **`JacksonScimSerializer`** implementation with sensible defaults: `KotlinModule`, `JavaTimeModule`, `ScimModule`, `NON_NULL` inclusion, ISO-8601 dates, `FAIL_ON_UNKNOWN_PROPERTIES=false`
- Add **`ScimModule`** (Jackson `SimpleModule`) as extension point for future SCIM-specific serializers/deserializers

## Test plan

- [x] SchemaIntrospector: introspect User -- all 21 attributes present with correct types, mutability, returned, uniqueness
- [x] SchemaIntrospector: introspect Group -- displayName required, members multi-valued complex
- [x] SchemaIntrospector: introspect EnterpriseUserExtension -- extension schema detected, manager has sub-attributes
- [x] SchemaIntrospector: type inference -- Boolean, URI (reference), complex types with sub-attributes
- [x] SchemaRegistry: register User + Group, retrieve by URI and name
- [x] SchemaRegistry: register extension, verify schema and resource type updated
- [x] SchemaRegistry: concurrent read safety (10 threads)
- [x] JacksonScimSerializer: User round-trip (minimal and full)
- [x] JacksonScimSerializer: Group round-trip with members
- [x] JacksonScimSerializer: extension data serialization
- [x] JacksonScimSerializer: null fields excluded from output
- [x] JacksonScimSerializer: Instant serialized as ISO-8601 (not timestamps)
- [x] JacksonScimSerializer: byte array serialize/deserialize

**32 tests, all passing.**

Generated with [Claude Code](https://claude.com/claude-code)