### PR TITLE
docs: Update ADR-0010 and ADR-0011 for OOTB persistence and IdP defaults

### DIFF
--- a/docs/adr/0010-no-database-opinion.md
+++ b/docs/adr/0010-no-database-opinion.md
@@ -1,28 +1,24 @@
-# ADR-0010: No Database Opinion
+# ADR-0010: Generic Core with OOTB Persistence Defaults
 
 ## Status
-
-Accepted
+Accepted (updated 2026-03-25, originally accepted as "No Database Opinion")
 
 ## Context
-
-SCIM service providers need to persist resources, but different organizations use different storage backends (PostgreSQL, MongoDB, DynamoDB, LDAP, in-memory). Coupling the SDK to a specific persistence technology would limit adoption.
+The SDK must not couple core/server modules to any specific database. However, requiring every user to implement `ResourceRepository<T>` from scratch creates unnecessary boilerplate for common setups. The spring-cloud-zuul-ratelimit project (https://github.com/marcosbarbero/spring-cloud-zuul-ratelimit) demonstrates an effective pattern: generic interfaces in the core with OOTB implementations that auto-configure based on classpath detection.
 
 ## Decision
-
-All persistence in the SDK is behind generic interfaces (e.g., `ResourceRepository<T>`). The SDK will not include any JPA, JDBC, or database-specific dependencies. Implementers provide their own persistence adapters.
+- Core and server modules define `ResourceRepository<T>` with zero database dependencies
+- The Spring Boot autoconfigure module provides OOTB default implementations:
+  - **JPA** (`JpaResourceRepository`) — auto-detected via `@ConditionalOnClass(EntityManager.class)`
+  - Additional backends (MongoDB, DynamoDB, etc.) can be added as separate adapter modules
+- Each default implementation:
+  - Is configurable via `scim.persistence.*` properties
+  - Provides expected database schema via Flyway/Liquibase migration files
+  - Backs off via `@ConditionalOnMissingBean` so users can replace with their own
+- The test module provides `InMemoryResourceRepository` for testing
 
 ## Consequences
-
-### Positive
-
-- SDK works with any storage backend
-- No transitive database driver dependencies
-- Clean separation between domain logic and persistence
-- Aligns with hexagonal architecture (ADR-0008)
-
-### Negative
-
-- Implementers must write their own persistence layer
-- Cannot provide out-of-the-box storage without additional modules
-- Common patterns (pagination, filtering) must be well-documented for implementers
+- Works OOTB for most users with JPA/Hibernate
+- Fully replaceable for custom or niche database setups
+- Core/server modules remain clean of database dependencies
+- Each new backend is an additive change (new module or auto-config class)

--- a/docs/adr/0011-no-idp-opinion.md
+++ b/docs/adr/0011-no-idp-opinion.md
@@ -1,28 +1,31 @@
-# ADR-0011: No IdP Opinion
+# ADR-0011: Generic Core with OOTB IdP Adapters
 
 ## Status
-
-Accepted
+Accepted (updated 2026-03-25, originally accepted as "No IdP Opinion")
 
 ## Context
-
-SCIM is often deployed alongside identity providers (IdPs) with OIDC, SAML, or other authentication mechanisms. Different organizations use different IdPs (Okta, Azure AD, Keycloak, custom) and authentication strategies.
+SCIM is inherently about identity provisioning — most deployments integrate with a specific Identity Provider. Requiring every user to implement `IdentityResolver` and `AuthenticationStrategy` from scratch creates unnecessary boilerplate for common IdPs. The SDK should work out of the box with major providers while remaining extensible for custom or niche providers.
 
 ## Decision
-
-Authentication and authorization in the SDK are behind generic interfaces (`IdentityResolver`, `AuthenticationStrategy`). The SDK will not include any IdP-specific dependencies in core or server modules.
+- Core and server modules define generic interfaces with zero IdP dependencies:
+  - `IdentityResolver` — resolves the authenticated principal from request context
+  - `AuthenticationStrategy` — handles token validation and authentication
+  - `AuthorizationEvaluator` — evaluates fine-grained authorization decisions
+- The Spring Boot autoconfigure module provides OOTB adapters for major IdPs:
+  - **Okta** — maps Okta JWT claims to SCIM identity
+  - **Azure AD (Entra ID)** — maps Azure AD / Microsoft Entra tokens and claims
+  - **Keycloak** — maps Keycloak realm tokens and roles
+  - **PingFederate** — maps PingFederate access tokens
+  - **Auth0** — maps Auth0 JWT claims
+- Each IdP adapter:
+  - Auto-detected via `@ConditionalOnClass` for the respective IdP SDK on classpath
+  - Configurable via `scim.idp.*` properties (issuer URL, client ID, claim mappings, etc.)
+  - Backs off via `@ConditionalOnMissingBean` so users can provide their own implementation
+- Additional IdP adapters can be contributed as separate modules or added to autoconfigure
 
 ## Consequences
-
-### Positive
-
-- SDK works with any IdP or authentication mechanism
-- No transitive IdP SDK dependencies
-- Implementers choose their own security stack
-- Spring Boot starter can optionally integrate with Spring Security
-
-### Negative
-
-- Implementers must wire their own authentication
-- Cannot provide turnkey IdP integration without additional modules
-- Security misconfiguration risk if implementers skip authentication
+- Works OOTB with the 5 most popular IdPs — no boilerplate needed
+- Fully extensible for custom, on-premise, or niche identity providers
+- Core/server modules remain clean of IdP SDK dependencies
+- Each new IdP adapter is an additive change
+- Aligns with Spring Security's OIDC/SAML resource server integration path


### PR DESCRIPTION
Update ADR-0010 to reflect OOTB JPA persistence defaults and ADR-0011 to reflect OOTB IdP adapters for Okta, Azure AD, Keycloak, PingFederate, Auth0. Pattern: generic core interfaces + auto-configured defaults that back off via @ConditionalOnMissingBean.