### PR TITLE
refactor: Extract SCIM URN strings into ScimUrns constants

### DIFF
--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/ScimUrns.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/ScimUrns.kt
@@ -1,0 +1,26 @@
+package com.marcosbarbero.scim2.core.domain
+
+/**
+ * SCIM 2.0 standard URN constants as defined in RFC 7643 and RFC 7644.
+ */
+object ScimUrns {
+    // Core resource schemas (RFC 7643)
+    const val USER: String = "urn:ietf:params:scim:schemas:core:2.0:User"
+    const val GROUP: String = "urn:ietf:params:scim:schemas:core:2.0:Group"
+
+    // Extension schemas (RFC 7643)
+    const val ENTERPRISE_USER: String = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+
+    // Discovery schemas (RFC 7643)
+    const val SERVICE_PROVIDER_CONFIG: String = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+    const val RESOURCE_TYPE: String = "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
+    const val SCHEMA: String = "urn:ietf:params:scim:schemas:core:2.0:Schema"
+
+    // Protocol message schemas (RFC 7644)
+    const val ERROR: String = "urn:ietf:params:scim:api:messages:2.0:Error"
+    const val LIST_RESPONSE: String = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+    const val SEARCH_REQUEST: String = "urn:ietf:params:scim:api:messages:2.0:SearchRequest"
+    const val PATCH_OP: String = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+    const val BULK_REQUEST: String = "urn:ietf:params:scim:api:messages:2.0:BulkRequest"
+    const val BULK_RESPONSE: String = "urn:ietf:params:scim:api:messages:2.0:BulkResponse"
+}

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/bulk/BulkRequest.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/bulk/BulkRequest.kt
@@ -1,9 +1,10 @@
 package com.marcosbarbero.scim2.core.domain.model.bulk
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 
 data class BulkRequest(
-    val schemas: List<String> = listOf("urn:ietf:params:scim:api:messages:2.0:BulkRequest"),
+    val schemas: List<String> = listOf(ScimUrns.BULK_REQUEST),
     val failOnErrors: Int? = null,
     @JsonProperty("Operations")
     val operations: List<BulkOperation> = emptyList()

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/bulk/BulkResponse.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/bulk/BulkResponse.kt
@@ -1,9 +1,10 @@
 package com.marcosbarbero.scim2.core.domain.model.bulk
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 
 data class BulkResponse(
-    val schemas: List<String> = listOf("urn:ietf:params:scim:api:messages:2.0:BulkResponse"),
+    val schemas: List<String> = listOf(ScimUrns.BULK_RESPONSE),
     @JsonProperty("Operations")
     val operations: List<BulkOperationResponse> = emptyList()
 )

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimError.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimError.kt
@@ -1,7 +1,9 @@
 package com.marcosbarbero.scim2.core.domain.model.error
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
+
 data class ScimError(
-    val schemas: List<String> = listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
+    val schemas: List<String> = listOf(ScimUrns.ERROR),
     val status: String,
     val scimType: String? = null,
     val detail: String? = null

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimException.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimException.kt
@@ -1,5 +1,7 @@
 package com.marcosbarbero.scim2.core.domain.model.error
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
+
 open class ScimException(
     val status: Int,
     val scimType: ScimErrorType? = null,
@@ -7,7 +9,7 @@ open class ScimException(
 ) : RuntimeException(detail) {
 
     fun toScimError(): ScimError = ScimError(
-        schemas = listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
+        schemas = listOf(ScimUrns.ERROR),
         status = status.toString(),
         scimType = scimType?.value,
         detail = detail

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/patch/PatchRequest.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/patch/PatchRequest.kt
@@ -1,9 +1,10 @@
 package com.marcosbarbero.scim2.core.domain.model.patch
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 
 data class PatchRequest(
-    val schemas: List<String> = listOf("urn:ietf:params:scim:api:messages:2.0:PatchOp"),
+    val schemas: List<String> = listOf(ScimUrns.PATCH_OP),
     @JsonProperty("Operations")
     val operations: List<PatchOperation> = emptyList()
 )

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/EnterpriseUserExtension.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/EnterpriseUserExtension.kt
@@ -1,9 +1,10 @@
 package com.marcosbarbero.scim2.core.domain.model.resource
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.common.Manager
 import com.marcosbarbero.scim2.core.schema.annotation.ScimExtension
 
-@ScimExtension(schema = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User")
+@ScimExtension(schema = ScimUrns.ENTERPRISE_USER)
 data class EnterpriseUserExtension(
     val employeeNumber: String? = null,
     val costCenter: String? = null,

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/Group.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/Group.kt
@@ -1,11 +1,12 @@
 package com.marcosbarbero.scim2.core.domain.model.resource
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.common.GroupMembership
 import com.marcosbarbero.scim2.core.domain.model.common.Meta
 import com.marcosbarbero.scim2.core.schema.annotation.ScimAttribute
 
 @com.marcosbarbero.scim2.core.schema.annotation.ScimResource(
-    schema = "urn:ietf:params:scim:schemas:core:2.0:Group",
+    schema = ScimUrns.GROUP,
     name = "Group",
     description = "Group",
     endpoint = "/Groups"
@@ -20,7 +21,7 @@ data class Group(
 
     val members: List<GroupMembership> = emptyList()
 ) : ScimResource(
-    schemas = listOf("urn:ietf:params:scim:schemas:core:2.0:Group"),
+    schemas = listOf(ScimUrns.GROUP),
     id = id,
     externalId = externalId,
     meta = meta

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/User.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/User.kt
@@ -5,6 +5,7 @@ import com.marcosbarbero.scim2.core.domain.model.common.GroupMembership
 import com.marcosbarbero.scim2.core.domain.model.common.Meta
 import com.marcosbarbero.scim2.core.domain.model.common.MultiValuedAttribute
 import com.marcosbarbero.scim2.core.domain.model.common.Name
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.schema.annotation.ScimAttribute
 import com.marcosbarbero.scim2.core.schema.annotation.Mutability
 import com.marcosbarbero.scim2.core.schema.annotation.Returned
@@ -12,7 +13,7 @@ import com.marcosbarbero.scim2.core.schema.annotation.Uniqueness
 import java.net.URI
 
 @com.marcosbarbero.scim2.core.schema.annotation.ScimResource(
-    schema = "urn:ietf:params:scim:schemas:core:2.0:User",
+    schema = ScimUrns.USER,
     name = "User",
     description = "User Account",
     endpoint = "/Users"
@@ -49,7 +50,7 @@ data class User(
     val roles: List<MultiValuedAttribute> = emptyList(),
     val x509Certificates: List<MultiValuedAttribute> = emptyList()
 ) : ScimResource(
-    schemas = listOf("urn:ietf:params:scim:schemas:core:2.0:User"),
+    schemas = listOf(ScimUrns.USER),
     id = id,
     externalId = externalId,
     meta = meta

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/search/ListResponse.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/search/ListResponse.kt
@@ -1,9 +1,10 @@
 package com.marcosbarbero.scim2.core.domain.model.search
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 
 data class ListResponse<T>(
-    val schemas: List<String> = listOf("urn:ietf:params:scim:api:messages:2.0:ListResponse"),
+    val schemas: List<String> = listOf(ScimUrns.LIST_RESPONSE),
     val totalResults: Int,
     val itemsPerPage: Int? = null,
     val startIndex: Int? = null,

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/search/SearchRequest.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/search/SearchRequest.kt
@@ -1,7 +1,9 @@
 package com.marcosbarbero.scim2.core.domain.model.search
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
+
 data class SearchRequest(
-    val schemas: List<String> = listOf("urn:ietf:params:scim:api:messages:2.0:SearchRequest"),
+    val schemas: List<String> = listOf(ScimUrns.SEARCH_REQUEST),
     val filter: String? = null,
     val sortBy: String? = null,
     val sortOrder: SortOrder? = null,

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/bulk/BulkModelsTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/bulk/BulkModelsTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.domain.model.bulk
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.serpro69.kfaker.Faker
@@ -27,7 +28,7 @@ class BulkModelsTest {
         val json = mapper.writeValueAsString(request)
         val deserialized = mapper.readValue<BulkRequest>(json)
 
-        deserialized.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:BulkRequest")
+        deserialized.schemas shouldBe listOf(ScimUrns.BULK_REQUEST)
         deserialized.failOnErrors shouldBe 1
         deserialized.operations.size shouldBe 2
         deserialized.operations[0].method shouldBe "POST"
@@ -53,7 +54,7 @@ class BulkModelsTest {
         val json = mapper.writeValueAsString(response)
         val deserialized = mapper.readValue<BulkResponse>(json)
 
-        deserialized.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:BulkResponse")
+        deserialized.schemas shouldBe listOf(ScimUrns.BULK_RESPONSE)
         deserialized.operations.size shouldBe 2
         deserialized.operations[0].status shouldBe "201"
         deserialized.operations[0].location shouldBe "https://example.com/v2/Users/$userId"

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimErrorTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimErrorTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.domain.model.error
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -143,7 +144,7 @@ class ScimErrorTest {
         fun `should serialize ScimError to JSON`() {
             val detail = faker.name.name()
             val error = ScimError(
-                schemas = listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
+                schemas = listOf(ScimUrns.ERROR),
                 status = "400",
                 scimType = "invalidFilter",
                 detail = detail
@@ -155,7 +156,7 @@ class ScimErrorTest {
             deserialized.status shouldBe "400"
             deserialized.scimType shouldBe "invalidFilter"
             deserialized.detail shouldBe detail
-            deserialized.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:Error")
+            deserialized.schemas shouldBe listOf(ScimUrns.ERROR)
         }
 
         @Test
@@ -184,7 +185,7 @@ class ScimErrorTest {
             error.status shouldBe "400"
             error.scimType shouldBe "invalidFilter"
             error.detail shouldBe detail
-            error.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:Error")
+            error.schemas shouldBe listOf(ScimUrns.ERROR)
         }
     }
 }

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/patch/PatchModelsTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/patch/PatchModelsTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.domain.model.patch
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.serpro69.kfaker.Faker
@@ -26,7 +27,7 @@ class PatchModelsTest {
         val json = mapper.writeValueAsString(request)
         val deserialized = mapper.readValue<PatchRequest>(json)
 
-        deserialized.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:PatchOp")
+        deserialized.schemas shouldBe listOf(ScimUrns.PATCH_OP)
         deserialized.operations.size shouldBe 3
         deserialized.operations[0].op shouldBe PatchOp.ADD
         deserialized.operations[1].op shouldBe PatchOp.REMOVE

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResourceTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResourceTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.domain.model.resource
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.common.Address
 import com.marcosbarbero.scim2.core.domain.model.common.GroupMembership
 import com.marcosbarbero.scim2.core.domain.model.common.Meta
@@ -30,7 +31,7 @@ class ScimResourceTest {
             val userName = faker.name.firstName().lowercase()
             val user = User(userName = userName)
             user.userName shouldBe userName
-            user.schemas shouldContain "urn:ietf:params:scim:schemas:core:2.0:User"
+            user.schemas shouldContain ScimUrns.USER
         }
 
         @Test
@@ -159,11 +160,11 @@ class ScimResourceTest {
                 division = division,
                 department = department
             )
-            user.setExtension("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", ext)
+            user.setExtension(ScimUrns.ENTERPRISE_USER, ext)
 
-            user.extensions shouldContainKey "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            user.extensions shouldContainKey ScimUrns.ENTERPRISE_USER
             val retrieved = user.getExtension<EnterpriseUserExtension>(
-                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+                ScimUrns.ENTERPRISE_USER
             )
             retrieved.shouldNotBeNull()
             retrieved.employeeNumber shouldBe employeeNumber
@@ -178,7 +179,7 @@ class ScimResourceTest {
             val groupName = faker.name.name()
             val group = Group(displayName = groupName)
             group.displayName shouldBe groupName
-            group.schemas shouldContain "urn:ietf:params:scim:schemas:core:2.0:Group"
+            group.schemas shouldContain ScimUrns.GROUP
         }
 
         @Test

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/search/SearchModelsTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/search/SearchModelsTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.domain.model.search
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.serpro69.kfaker.Faker
@@ -26,7 +27,7 @@ class SearchModelsTest {
         val json = mapper.writeValueAsString(request)
         val deserialized = mapper.readValue<SearchRequest>(json)
 
-        deserialized.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:SearchRequest")
+        deserialized.schemas shouldBe listOf(ScimUrns.SEARCH_REQUEST)
         deserialized.filter shouldBe "userName eq \"$userName\""
         deserialized.sortBy shouldBe "userName"
         deserialized.sortOrder shouldBe SortOrder.DESCENDING
@@ -49,7 +50,7 @@ class SearchModelsTest {
         val json = mapper.writeValueAsString(response)
         val deserialized = mapper.readValue<ListResponse<Map<String, String>>>(json)
 
-        deserialized.schemas shouldBe listOf("urn:ietf:params:scim:api:messages:2.0:ListResponse")
+        deserialized.schemas shouldBe listOf(ScimUrns.LIST_RESPONSE)
         deserialized.totalResults shouldBe 100
         deserialized.itemsPerPage shouldBe 10
         deserialized.resources.size shouldBe 2

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/vo/ValueObjectsTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/vo/ValueObjectsTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.domain.vo
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import io.github.serpro69.kfaker.Faker
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -36,7 +37,7 @@ class ValueObjectsTest {
 
         @Test
         fun `toString returns the value`() {
-            val urn = "urn:ietf:params:scim:schemas:core:2.0:User"
+            val urn = ScimUrns.USER
             val uri = SchemaUri(urn)
             uri.toString() shouldBe urn
         }

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/lexer/FilterLexerTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/lexer/FilterLexerTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.filter.lexer
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
 import io.github.serpro69.kfaker.Faker
 import io.kotest.assertions.throwables.shouldThrow
@@ -40,10 +41,10 @@ class FilterLexerTest {
 
         @Test
         fun `should tokenize URN-prefixed attribute path`() {
-            val tokens = tokenize("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department")
+            val tokens = tokenize("${ScimUrns.ENTERPRISE_USER}:department")
             tokens shouldHaveSize 2
             tokens[0].type shouldBe TokenType.ATTR_PATH
-            tokens[0].value shouldBe "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department"
+            tokens[0].value shouldBe "${ScimUrns.ENTERPRISE_USER}:department"
         }
     }
 

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/parser/FilterParserTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/filter/parser/FilterParserTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.filter.parser
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
 import com.marcosbarbero.scim2.core.filter.ast.AttributeExpression
 import com.marcosbarbero.scim2.core.filter.ast.AttributePath
@@ -235,9 +236,9 @@ class FilterParserTest {
         @Test
         fun `should parse URN-prefixed attribute path`() {
             val dept = faker.name.name()
-            val node = parse("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department eq \"$dept\"")
+            val node = parse("${ScimUrns.ENTERPRISE_USER}:department eq \"$dept\"")
             node.shouldBeInstanceOf<AttributeExpression>()
-            node.path.schemaUri shouldBe "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            node.path.schemaUri shouldBe ScimUrns.ENTERPRISE_USER
             node.path.attributeName shouldBe "department"
         }
     }

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/annotation/AnnotationsTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/annotation/AnnotationsTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.schema.annotation
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.resource.EnterpriseUserExtension
 import com.marcosbarbero.scim2.core.domain.model.resource.Group
 import com.marcosbarbero.scim2.core.domain.model.resource.User
@@ -16,7 +17,7 @@ class AnnotationsTest {
     fun `User class should have ScimResource annotation`() {
         val annotation = User::class.java.getAnnotation(ScimResource::class.java)
         annotation.shouldNotBeNull()
-        annotation.schema shouldBe "urn:ietf:params:scim:schemas:core:2.0:User"
+        annotation.schema shouldBe ScimUrns.USER
         annotation.name shouldBe "User"
         annotation.endpoint shouldBe "/Users"
     }
@@ -25,7 +26,7 @@ class AnnotationsTest {
     fun `Group class should have ScimResource annotation`() {
         val annotation = Group::class.java.getAnnotation(ScimResource::class.java)
         annotation.shouldNotBeNull()
-        annotation.schema shouldBe "urn:ietf:params:scim:schemas:core:2.0:Group"
+        annotation.schema shouldBe ScimUrns.GROUP
         annotation.name shouldBe "Group"
         annotation.endpoint shouldBe "/Groups"
     }
@@ -34,7 +35,7 @@ class AnnotationsTest {
     fun `EnterpriseUserExtension should have ScimExtension annotation`() {
         val annotation = EnterpriseUserExtension::class.java.getAnnotation(ScimExtension::class.java)
         annotation.shouldNotBeNull()
-        annotation.schema shouldBe "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        annotation.schema shouldBe ScimUrns.ENTERPRISE_USER
     }
 
     @Test

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaIntrospectorTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaIntrospectorTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.schema.introspector
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.resource.EnterpriseUserExtension
 import com.marcosbarbero.scim2.core.domain.model.resource.Group
 import com.marcosbarbero.scim2.core.domain.model.resource.User
@@ -27,7 +28,7 @@ class SchemaIntrospectorTest {
         @Test
         fun `should introspect User schema with correct id and name`() {
             val schema = introspector.introspect(User::class)
-            schema.id shouldBe "urn:ietf:params:scim:schemas:core:2.0:User"
+            schema.id shouldBe ScimUrns.USER
             schema.name shouldBe "User"
             schema.description shouldBe "User Account"
         }
@@ -120,7 +121,7 @@ class SchemaIntrospectorTest {
         @Test
         fun `should introspect Group schema with correct id`() {
             val schema = introspector.introspect(Group::class)
-            schema.id shouldBe "urn:ietf:params:scim:schemas:core:2.0:Group"
+            schema.id shouldBe ScimUrns.GROUP
             schema.name shouldBe "Group"
         }
 
@@ -150,7 +151,7 @@ class SchemaIntrospectorTest {
             resourceType.id shouldBe "User"
             resourceType.name shouldBe "User"
             resourceType.endpoint shouldBe "/Users"
-            resourceType.schema shouldBe "urn:ietf:params:scim:schemas:core:2.0:User"
+            resourceType.schema shouldBe ScimUrns.USER
         }
 
         @Test
@@ -159,7 +160,7 @@ class SchemaIntrospectorTest {
             resourceType.id shouldBe "Group"
             resourceType.name shouldBe "Group"
             resourceType.endpoint shouldBe "/Groups"
-            resourceType.schema shouldBe "urn:ietf:params:scim:schemas:core:2.0:Group"
+            resourceType.schema shouldBe ScimUrns.GROUP
         }
     }
 
@@ -169,7 +170,7 @@ class SchemaIntrospectorTest {
         @Test
         fun `should introspect extension schema`() {
             val schema = introspector.introspect(EnterpriseUserExtension::class)
-            schema.id shouldBe "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            schema.id shouldBe ScimUrns.ENTERPRISE_USER
             val attrNames = schema.attributes.map { it.name }
             attrNames shouldContain "employeeNumber"
             attrNames shouldContain "costCenter"

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaRegistryTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaRegistryTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.schema.introspector
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.resource.EnterpriseUserExtension
 import com.marcosbarbero.scim2.core.domain.model.resource.Group
 import com.marcosbarbero.scim2.core.domain.model.resource.User
@@ -30,17 +31,17 @@ class SchemaRegistryTest {
         @Test
         fun `should register and retrieve User schema`() {
             registry.register(User::class)
-            val schema = registry.getSchema("urn:ietf:params:scim:schemas:core:2.0:User")
+            val schema = registry.getSchema(ScimUrns.USER)
             schema.shouldNotBeNull()
-            schema.id shouldBe "urn:ietf:params:scim:schemas:core:2.0:User"
+            schema.id shouldBe ScimUrns.USER
         }
 
         @Test
         fun `should register and retrieve Group schema`() {
             registry.register(Group::class)
-            val schema = registry.getSchema("urn:ietf:params:scim:schemas:core:2.0:Group")
+            val schema = registry.getSchema(ScimUrns.GROUP)
             schema.shouldNotBeNull()
-            schema.id shouldBe "urn:ietf:params:scim:schemas:core:2.0:Group"
+            schema.id shouldBe ScimUrns.GROUP
         }
 
         @Test
@@ -89,7 +90,7 @@ class SchemaRegistryTest {
             resourceType.shouldNotBeNull()
             resourceType.schemaExtensions shouldHaveSize 1
             resourceType.schemaExtensions[0].schema shouldBe
-                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+                ScimUrns.ENTERPRISE_USER
         }
 
         @Test
@@ -98,7 +99,7 @@ class SchemaRegistryTest {
             registry.registerExtension(User::class, EnterpriseUserExtension::class)
 
             val extSchema = registry.getSchema(
-                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+                ScimUrns.ENTERPRISE_USER
             )
             extSchema.shouldNotBeNull()
             extSchema.attributes.map { it.name }.toSet() shouldBe setOf(
@@ -123,8 +124,8 @@ class SchemaRegistryTest {
             repeat(threadCount) {
                 executor.submit {
                     try {
-                        val user = registry.getSchema("urn:ietf:params:scim:schemas:core:2.0:User")
-                        val group = registry.getSchema("urn:ietf:params:scim:schemas:core:2.0:Group")
+                        val user = registry.getSchema(ScimUrns.USER)
+                        val group = registry.getSchema(ScimUrns.GROUP)
                         val allSchemas = registry.getAllSchemas()
                         val allTypes = registry.getAllResourceTypes()
                         synchronized(results) {

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/serialization/jackson/JacksonScimSerializerTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/serialization/jackson/JacksonScimSerializerTest.kt
@@ -1,5 +1,6 @@
 package com.marcosbarbero.scim2.core.serialization.jackson
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.domain.model.common.Address
 import com.marcosbarbero.scim2.core.domain.model.common.GroupMembership
 import com.marcosbarbero.scim2.core.domain.model.common.Meta
@@ -177,7 +178,7 @@ class JacksonScimSerializerTest {
             val organization = faker.name.name()
             val user = User(userName = faker.name.firstName().lowercase())
             user.setExtension(
-                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+                ScimUrns.ENTERPRISE_USER,
                 mapOf(
                     "employeeNumber" to employeeNumber,
                     "costCenter" to costCenter,
@@ -186,12 +187,12 @@ class JacksonScimSerializerTest {
             )
 
             val json = serializer.serializeToString(user)
-            json shouldContain "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            json shouldContain ScimUrns.ENTERPRISE_USER
             json shouldContain employeeNumber
 
             val deserialized = serializer.deserializeFromString(json, User::class)
             val ext = deserialized.getExtension<Map<*, *>>(
-                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+                ScimUrns.ENTERPRISE_USER
             )
             ext shouldBe mapOf(
                 "employeeNumber" to employeeNumber,


### PR DESCRIPTION
## Summary
- Introduces `ScimUrns` constants object in `com.marcosbarbero.scim2.core.domain` with all standard SCIM 2.0 URN strings (RFC 7643/7644)
- Replaces hardcoded URN strings across 10 production files and 12 test files with references to `ScimUrns.*`
- Uses `const val` to ensure compile-time constant compatibility (required for annotation parameters)

## Test plan
- [x] All 193 existing tests pass (`mvn clean verify -pl scim2-sdk-core -am`)
- [x] Verified no hardcoded URN strings remain in production source (only in `ScimUrns.kt`)
- [x] Annotation parameters (`@ScimResource`, `@ScimExtension`) correctly use `const val` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)