### PR TITLE
feat: Client module - ScimClient, HttpTransport SPI, JavaHttpClientTransport

### DIFF
--- a/scim2-sdk-client-httpclient/pom.xml
+++ b/scim2-sdk-client-httpclient/pom.xml
@@ -21,5 +21,22 @@
             <groupId>com.marcosbarbero</groupId>
             <artifactId>scim2-sdk-client</artifactId>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.serpro69</groupId>
+            <artifactId>kotlin-faker</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/scim2-sdk-client-httpclient/src/main/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/JavaHttpClientTransport.kt
+++ b/scim2-sdk-client-httpclient/src/main/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/JavaHttpClientTransport.kt
@@ -1,0 +1,44 @@
+package com.marcosbarbero.scim2.client.adapter.httpclient
+
+import com.marcosbarbero.scim2.client.port.HttpRequest
+import com.marcosbarbero.scim2.client.port.HttpResponse
+import com.marcosbarbero.scim2.client.port.HttpTransport
+import java.net.URI
+import java.net.http.HttpClient
+
+class JavaHttpClientTransport(
+    private val httpClient: HttpClient = HttpClient.newHttpClient()
+) : HttpTransport {
+
+    override fun execute(request: HttpRequest): HttpResponse {
+        val bodyPublisher = if (request.body != null) {
+            java.net.http.HttpRequest.BodyPublishers.ofByteArray(request.body)
+        } else {
+            java.net.http.HttpRequest.BodyPublishers.noBody()
+        }
+
+        val builder = java.net.http.HttpRequest.newBuilder()
+            .uri(URI.create(request.url))
+            .method(request.method, bodyPublisher)
+
+        request.headers.forEach { (key, value) ->
+            builder.header(key, value)
+        }
+
+        val javaRequest = builder.build()
+        val javaResponse = httpClient.send(javaRequest, java.net.http.HttpResponse.BodyHandlers.ofByteArray())
+
+        val responseHeaders = javaResponse.headers().map().mapValues { (_, values) -> values.toList() }
+        val responseBody = javaResponse.body()?.takeIf { it.isNotEmpty() }
+
+        return HttpResponse(
+            statusCode = javaResponse.statusCode(),
+            headers = responseHeaders,
+            body = responseBody
+        )
+    }
+
+    override fun close() {
+        // Java HttpClient does not require explicit close
+    }
+}

--- a/scim2-sdk-client-httpclient/src/test/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/JavaHttpClientTransportTest.kt
+++ b/scim2-sdk-client-httpclient/src/test/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/JavaHttpClientTransportTest.kt
@@ -1,0 +1,153 @@
+package com.marcosbarbero.scim2.client.adapter.httpclient
+
+import com.marcosbarbero.scim2.client.port.HttpRequest
+import com.sun.net.httpserver.HttpServer
+import io.github.serpro69.kfaker.Faker
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+
+class JavaHttpClientTransportTest {
+
+    private val faker = Faker()
+    private lateinit var server: HttpServer
+    private lateinit var transport: JavaHttpClientTransport
+    private var port: Int = 0
+
+    @BeforeEach
+    fun setUp() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        port = server.address.port
+        transport = JavaHttpClientTransport()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.stop(0)
+        transport.close()
+    }
+
+    @Test
+    fun `execute sends GET request and returns response`() {
+        val responseText = faker.random.randomString(20)
+        server.createContext("/test") { exchange ->
+            val body = responseText.toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+
+        val request = HttpRequest(
+            method = "GET",
+            url = "http://localhost:$port/test"
+        )
+
+        val response = transport.execute(request)
+
+        response.statusCode shouldBe 200
+        response.body shouldNotBe null
+        String(response.body!!) shouldBe responseText
+    }
+
+    @Test
+    fun `execute sends POST request with body`() {
+        val requestText = faker.random.randomString(30)
+        var receivedBody: String? = null
+        var receivedContentType: String? = null
+
+        server.createContext("/users") { exchange ->
+            receivedBody = exchange.requestBody.bufferedReader().readText()
+            receivedContentType = exchange.requestHeaders.getFirst("Content-Type")
+            val responseBody = """{"id":"1"}""".toByteArray()
+            exchange.sendResponseHeaders(201, responseBody.size.toLong())
+            exchange.responseBody.use { it.write(responseBody) }
+        }
+        server.start()
+
+        val request = HttpRequest(
+            method = "POST",
+            url = "http://localhost:$port/users",
+            headers = mapOf("Content-Type" to "application/scim+json"),
+            body = requestText.toByteArray()
+        )
+
+        val response = transport.execute(request)
+
+        response.statusCode shouldBe 201
+        receivedBody shouldBe requestText
+        receivedContentType shouldBe "application/scim+json"
+    }
+
+    @Test
+    fun `execute maps response headers correctly`() {
+        server.createContext("/headers") { exchange ->
+            exchange.responseHeaders.add("X-Custom", "value1")
+            exchange.responseHeaders.add("ETag", "W/\"abc\"")
+            exchange.sendResponseHeaders(200, -1)
+            exchange.close()
+        }
+        server.start()
+
+        val request = HttpRequest(
+            method = "GET",
+            url = "http://localhost:$port/headers"
+        )
+
+        val response = transport.execute(request)
+
+        response.statusCode shouldBe 200
+        response.headers.entries
+            .firstOrNull { it.key.equals("X-custom", ignoreCase = true) }
+            ?.value?.first() shouldBe "value1"
+        response.headers.entries
+            .firstOrNull { it.key.equals("Etag", ignoreCase = true) }
+            ?.value?.first() shouldBe "W/\"abc\""
+    }
+
+    @Test
+    fun `execute sends request headers to server`() {
+        var receivedAuth: String? = null
+
+        server.createContext("/auth") { exchange ->
+            receivedAuth = exchange.requestHeaders.getFirst("Authorization")
+            exchange.sendResponseHeaders(200, -1)
+            exchange.close()
+        }
+        server.start()
+
+        val request = HttpRequest(
+            method = "GET",
+            url = "http://localhost:$port/auth",
+            headers = mapOf("Authorization" to "Bearer my-token")
+        )
+
+        transport.execute(request)
+
+        receivedAuth shouldBe "Bearer my-token"
+    }
+
+    @Test
+    fun `execute handles DELETE request`() {
+        var receivedMethod: String? = null
+
+        server.createContext("/users/123") { exchange ->
+            receivedMethod = exchange.requestMethod
+            exchange.sendResponseHeaders(204, -1)
+            exchange.close()
+        }
+        server.start()
+
+        val request = HttpRequest(
+            method = "DELETE",
+            url = "http://localhost:$port/users/123"
+        )
+
+        val response = transport.execute(request)
+
+        response.statusCode shouldBe 204
+        receivedMethod shouldBe "DELETE"
+    }
+}

--- a/scim2-sdk-client/pom.xml
+++ b/scim2-sdk-client/pom.xml
@@ -25,5 +25,37 @@
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.serpro69</groupId>
+            <artifactId>kotlin-faker</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClient.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClient.kt
@@ -1,0 +1,172 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.client.error.ScimClientException
+import com.marcosbarbero.scim2.client.port.AuthenticationStrategy
+import com.marcosbarbero.scim2.client.port.HttpRequest
+import com.marcosbarbero.scim2.client.port.HttpResponse
+import com.marcosbarbero.scim2.client.port.HttpTransport
+import com.marcosbarbero.scim2.core.domain.model.bulk.BulkRequest
+import com.marcosbarbero.scim2.core.domain.model.bulk.BulkResponse
+import com.marcosbarbero.scim2.core.domain.model.error.ScimError
+import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
+import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
+import com.marcosbarbero.scim2.core.domain.model.schema.ResourceType
+import com.marcosbarbero.scim2.core.domain.model.schema.Schema
+import com.marcosbarbero.scim2.core.domain.model.schema.ServiceProviderConfig
+import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
+import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import kotlin.reflect.KClass
+
+internal class DefaultScimClient(
+    private val baseUrl: String,
+    private val transport: HttpTransport,
+    private val serializer: ScimSerializer,
+    private val authentication: AuthenticationStrategy?,
+    private val defaultHeaders: Map<String, String>
+) : ScimClient {
+
+    companion object {
+        private const val CONTENT_TYPE = "Content-Type"
+        private const val ACCEPT = "Accept"
+        private const val SCIM_MEDIA_TYPE = "application/scim+json"
+        private const val ETAG_HEADER = "ETag"
+        private const val LOCATION_HEADER = "Location"
+    }
+
+    override fun <T : ScimResource> create(endpoint: String, resource: T, type: KClass<T>): ScimResponse<T> {
+        val body = serializer.serialize(resource)
+        val request = buildRequest("POST", "$baseUrl$endpoint", body)
+        val response = executeRequest(request)
+        checkForErrors(response)
+        val value = serializer.deserialize(response.body!!, type)
+        return toScimResponse(value, response)
+    }
+
+    override fun <T : ScimResource> get(endpoint: String, id: String, type: KClass<T>): ScimResponse<T> {
+        val request = buildRequest("GET", "$baseUrl$endpoint/$id")
+        val response = executeRequest(request)
+        checkForErrors(response)
+        val value = serializer.deserialize(response.body!!, type)
+        return toScimResponse(value, response)
+    }
+
+    override fun <T : ScimResource> replace(endpoint: String, id: String, resource: T, type: KClass<T>): ScimResponse<T> {
+        val body = serializer.serialize(resource)
+        val request = buildRequest("PUT", "$baseUrl$endpoint/$id", body)
+        val response = executeRequest(request)
+        checkForErrors(response)
+        val value = serializer.deserialize(response.body!!, type)
+        return toScimResponse(value, response)
+    }
+
+    override fun <T : ScimResource> patch(endpoint: String, id: String, patchRequest: PatchRequest, type: KClass<T>): ScimResponse<T> {
+        val body = serializer.serialize(patchRequest)
+        val request = buildRequest("PATCH", "$baseUrl$endpoint/$id", body)
+        val response = executeRequest(request)
+        checkForErrors(response)
+        val value = serializer.deserialize(response.body!!, type)
+        return toScimResponse(value, response)
+    }
+
+    override fun delete(endpoint: String, id: String) {
+        val request = buildRequest("DELETE", "$baseUrl$endpoint/$id")
+        val response = executeRequest(request)
+        checkForErrors(response)
+    }
+
+    override fun <T : ScimResource> search(endpoint: String, searchRequest: SearchRequest, type: KClass<T>): ScimResponse<ListResponse<T>> {
+        val body = serializer.serialize(searchRequest)
+        val request = buildRequest("POST", "$baseUrl$endpoint/.search", body)
+        val response = executeRequest(request)
+        checkForErrors(response)
+        @Suppress("UNCHECKED_CAST")
+        val listResponse = serializer.deserialize(response.body!!, ListResponse::class) as ListResponse<T>
+        return toScimResponse(listResponse, response)
+    }
+
+    override fun bulk(bulkRequest: BulkRequest): ScimResponse<BulkResponse> {
+        val body = serializer.serialize(bulkRequest)
+        val request = buildRequest("POST", "$baseUrl/Bulk", body)
+        val response = executeRequest(request)
+        checkForErrors(response)
+        val value = serializer.deserialize(response.body!!, BulkResponse::class)
+        return toScimResponse(value, response)
+    }
+
+    override fun getServiceProviderConfig(): ScimResponse<ServiceProviderConfig> {
+        val request = buildRequest("GET", "$baseUrl/ServiceProviderConfig")
+        val response = executeRequest(request)
+        checkForErrors(response)
+        val value = serializer.deserialize(response.body!!, ServiceProviderConfig::class)
+        return toScimResponse(value, response)
+    }
+
+    override fun getSchemas(): ScimResponse<ListResponse<Schema>> {
+        val request = buildRequest("GET", "$baseUrl/Schemas")
+        val response = executeRequest(request)
+        checkForErrors(response)
+        @Suppress("UNCHECKED_CAST")
+        val value = serializer.deserialize(response.body!!, ListResponse::class) as ListResponse<Schema>
+        return toScimResponse(value, response)
+    }
+
+    override fun getResourceTypes(): ScimResponse<ListResponse<ResourceType>> {
+        val request = buildRequest("GET", "$baseUrl/ResourceTypes")
+        val response = executeRequest(request)
+        checkForErrors(response)
+        @Suppress("UNCHECKED_CAST")
+        val value = serializer.deserialize(response.body!!, ListResponse::class) as ListResponse<ResourceType>
+        return toScimResponse(value, response)
+    }
+
+    override fun close() {
+        transport.close()
+    }
+
+    private fun buildRequest(method: String, url: String, body: ByteArray? = null): HttpRequest {
+        val headers = buildMap {
+            putAll(defaultHeaders)
+            put(ACCEPT, SCIM_MEDIA_TYPE)
+            if (body != null) {
+                put(CONTENT_TYPE, SCIM_MEDIA_TYPE)
+            }
+        }
+        return HttpRequest(method = method, url = url, headers = headers, body = body)
+    }
+
+    private fun executeRequest(request: HttpRequest): HttpResponse {
+        val authenticatedRequest = authentication?.authenticate(request) ?: request
+        return transport.execute(authenticatedRequest)
+    }
+
+    private fun checkForErrors(response: HttpResponse) {
+        if (response.statusCode in 400..599) {
+            val scimError = response.body?.let {
+                try {
+                    serializer.deserialize(it, ScimError::class)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+            throw ScimClientException(
+                statusCode = response.statusCode,
+                scimError = scimError
+            )
+        }
+    }
+
+    private fun <T> toScimResponse(value: T, response: HttpResponse): ScimResponse<T> {
+        return ScimResponse(
+            value = value,
+            statusCode = response.statusCode,
+            headers = response.headers,
+            etag = response.headers.entries
+                .firstOrNull { it.key.equals(ETAG_HEADER, ignoreCase = true) }
+                ?.value?.firstOrNull(),
+            location = response.headers.entries
+                .firstOrNull { it.key.equals(LOCATION_HEADER, ignoreCase = true) }
+                ?.value?.firstOrNull()
+        )
+    }
+}

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClient.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClient.kt
@@ -1,0 +1,50 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.core.domain.model.bulk.BulkRequest
+import com.marcosbarbero.scim2.core.domain.model.bulk.BulkResponse
+import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
+import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
+import com.marcosbarbero.scim2.core.domain.model.schema.ResourceType
+import com.marcosbarbero.scim2.core.domain.model.schema.Schema
+import com.marcosbarbero.scim2.core.domain.model.schema.ServiceProviderConfig
+import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
+import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+import kotlin.reflect.KClass
+
+interface ScimClient : AutoCloseable {
+
+    fun <T : ScimResource> create(endpoint: String, resource: T, type: KClass<T>): ScimResponse<T>
+
+    fun <T : ScimResource> get(endpoint: String, id: String, type: KClass<T>): ScimResponse<T>
+
+    fun <T : ScimResource> replace(endpoint: String, id: String, resource: T, type: KClass<T>): ScimResponse<T>
+
+    fun <T : ScimResource> patch(endpoint: String, id: String, patchRequest: PatchRequest, type: KClass<T>): ScimResponse<T>
+
+    fun delete(endpoint: String, id: String)
+
+    fun <T : ScimResource> search(endpoint: String, searchRequest: SearchRequest, type: KClass<T>): ScimResponse<ListResponse<T>>
+
+    fun bulk(bulkRequest: BulkRequest): ScimResponse<BulkResponse>
+
+    fun getServiceProviderConfig(): ScimResponse<ServiceProviderConfig>
+
+    fun getSchemas(): ScimResponse<ListResponse<Schema>>
+
+    fun getResourceTypes(): ScimResponse<ListResponse<ResourceType>>
+}
+
+inline fun <reified T : ScimResource> ScimClient.create(endpoint: String, resource: T): ScimResponse<T> =
+    create(endpoint, resource, T::class)
+
+inline fun <reified T : ScimResource> ScimClient.get(endpoint: String, id: String): ScimResponse<T> =
+    get(endpoint, id, T::class)
+
+inline fun <reified T : ScimResource> ScimClient.replace(endpoint: String, id: String, resource: T): ScimResponse<T> =
+    replace(endpoint, id, resource, T::class)
+
+inline fun <reified T : ScimResource> ScimClient.patch(endpoint: String, id: String, patchRequest: PatchRequest): ScimResponse<T> =
+    patch(endpoint, id, patchRequest, T::class)
+
+inline fun <reified T : ScimResource> ScimClient.search(endpoint: String, searchRequest: SearchRequest): ScimResponse<ListResponse<T>> =
+    search(endpoint, searchRequest, T::class)

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClientBuilder.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClientBuilder.kt
@@ -1,0 +1,37 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.client.port.AuthenticationStrategy
+import com.marcosbarbero.scim2.client.port.HttpTransport
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+
+class ScimClientBuilder {
+    private var baseUrl: String? = null
+    private var transport: HttpTransport? = null
+    private var serializer: ScimSerializer? = null
+    private var authentication: AuthenticationStrategy? = null
+    private var defaultHeaders: Map<String, String> = emptyMap()
+
+    fun baseUrl(url: String): ScimClientBuilder = apply { this.baseUrl = url }
+
+    fun transport(transport: HttpTransport): ScimClientBuilder = apply { this.transport = transport }
+
+    fun serializer(serializer: ScimSerializer): ScimClientBuilder = apply { this.serializer = serializer }
+
+    fun authentication(auth: AuthenticationStrategy): ScimClientBuilder = apply { this.authentication = auth }
+
+    fun defaultHeaders(headers: Map<String, String>): ScimClientBuilder = apply { this.defaultHeaders = headers }
+
+    fun build(): ScimClient {
+        val resolvedBaseUrl = requireNotNull(baseUrl) { "baseUrl must be set" }.trimEnd('/')
+        val resolvedTransport = requireNotNull(transport) { "transport must be set" }
+        val resolvedSerializer = requireNotNull(serializer) { "serializer must be set" }
+
+        return DefaultScimClient(
+            baseUrl = resolvedBaseUrl,
+            transport = resolvedTransport,
+            serializer = resolvedSerializer,
+            authentication = authentication,
+            defaultHeaders = defaultHeaders
+        )
+    }
+}

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimResponse.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimResponse.kt
@@ -1,0 +1,9 @@
+package com.marcosbarbero.scim2.client.api
+
+data class ScimResponse<T>(
+    val value: T,
+    val statusCode: Int,
+    val headers: Map<String, List<String>> = emptyMap(),
+    val etag: String? = null,
+    val location: String? = null
+)

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/error/ScimClientException.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/error/ScimClientException.kt
@@ -1,0 +1,10 @@
+package com.marcosbarbero.scim2.client.error
+
+import com.marcosbarbero.scim2.core.domain.model.error.ScimError
+
+class ScimClientException(
+    val statusCode: Int,
+    val scimError: ScimError? = null,
+    message: String? = null,
+    cause: Throwable? = null
+) : RuntimeException(message ?: scimError?.detail ?: "SCIM client error ($statusCode)", cause)

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/port/AuthenticationStrategy.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/port/AuthenticationStrategy.kt
@@ -1,0 +1,19 @@
+package com.marcosbarbero.scim2.client.port
+
+import java.util.Base64
+
+interface AuthenticationStrategy {
+    fun authenticate(request: HttpRequest): HttpRequest
+}
+
+class BearerTokenAuthentication(private val token: String) : AuthenticationStrategy {
+    override fun authenticate(request: HttpRequest): HttpRequest =
+        request.copy(headers = request.headers + ("Authorization" to "Bearer $token"))
+}
+
+class BasicAuthentication(private val username: String, private val password: String) : AuthenticationStrategy {
+    override fun authenticate(request: HttpRequest): HttpRequest {
+        val encoded = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
+        return request.copy(headers = request.headers + ("Authorization" to "Basic $encoded"))
+    }
+}

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/port/HttpTransport.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/port/HttpTransport.kt
@@ -1,0 +1,50 @@
+package com.marcosbarbero.scim2.client.port
+
+data class HttpRequest(
+    val method: String,
+    val url: String,
+    val headers: Map<String, String> = emptyMap(),
+    val body: ByteArray? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is HttpRequest) return false
+        return method == other.method &&
+            url == other.url &&
+            headers == other.headers &&
+            body.contentEquals(other.body)
+    }
+
+    override fun hashCode(): Int {
+        var result = method.hashCode()
+        result = 31 * result + url.hashCode()
+        result = 31 * result + headers.hashCode()
+        result = 31 * result + (body?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+data class HttpResponse(
+    val statusCode: Int,
+    val headers: Map<String, List<String>> = emptyMap(),
+    val body: ByteArray? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is HttpResponse) return false
+        return statusCode == other.statusCode &&
+            headers == other.headers &&
+            body.contentEquals(other.body)
+    }
+
+    override fun hashCode(): Int {
+        var result = statusCode.hashCode()
+        result = 31 * result + headers.hashCode()
+        result = 31 * result + (body?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+interface HttpTransport : AutoCloseable {
+    fun execute(request: HttpRequest): HttpResponse
+}

--- a/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClientTest.kt
+++ b/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClientTest.kt
@@ -1,0 +1,313 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.client.error.ScimClientException
+import com.marcosbarbero.scim2.client.port.AuthenticationStrategy
+import com.marcosbarbero.scim2.client.port.BearerTokenAuthentication
+import com.marcosbarbero.scim2.client.port.HttpRequest
+import com.marcosbarbero.scim2.client.port.HttpResponse
+import com.marcosbarbero.scim2.client.port.HttpTransport
+import com.marcosbarbero.scim2.core.domain.ScimUrns
+import com.marcosbarbero.scim2.core.domain.model.bulk.BulkRequest
+import com.marcosbarbero.scim2.core.domain.model.bulk.BulkResponse
+import com.marcosbarbero.scim2.core.domain.model.error.ScimError
+import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.domain.model.schema.ServiceProviderConfig
+import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
+import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import io.github.serpro69.kfaker.Faker
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+class DefaultScimClientTest {
+
+    private val faker = Faker()
+    private lateinit var transport: HttpTransport
+    private lateinit var serializer: ScimSerializer
+    private lateinit var client: ScimClient
+
+    private val baseUrl = "https://scim.example.com"
+
+    @BeforeEach
+    fun setUp() {
+        transport = mockk(relaxed = true)
+        serializer = mockk(relaxed = true)
+        client = ScimClientBuilder()
+            .baseUrl(baseUrl)
+            .transport(transport)
+            .serializer(serializer)
+            .authentication(BearerTokenAuthentication("test-token"))
+            .build()
+    }
+
+    @Test
+    fun `create sends POST request and returns 201 with resource`() {
+        val userName = faker.name.firstName()
+        val user = User(userName = userName)
+        val createdUser = User(id = "123", userName = userName)
+        val serializedBody = """{"userName":"$userName"}""".toByteArray()
+        val responseBody = """{"id":"123","userName":"$userName"}""".toByteArray()
+
+        every { serializer.serialize(user) } returns serializedBody
+        every { serializer.deserialize(responseBody, User::class) } returns createdUser
+        every { transport.execute(any()) } returns HttpResponse(
+            statusCode = 201,
+            headers = mapOf(
+                "ETag" to listOf("W/\"1\""),
+                "Location" to listOf("$baseUrl/Users/123")
+            ),
+            body = responseBody
+        )
+
+        val response = client.create("/Users", user, User::class)
+
+        response.statusCode shouldBe 201
+        response.value shouldBe createdUser
+        response.etag shouldBe "W/\"1\""
+        response.location shouldBe "$baseUrl/Users/123"
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.method shouldBe "POST"
+        requestSlot.captured.url shouldBe "$baseUrl/Users"
+    }
+
+    @Test
+    fun `get sends GET request and returns 200 with resource`() {
+        val userId = faker.random.randomString(10)
+        val user = User(id = userId, userName = "john")
+        val responseBody = """{"id":"$userId"}""".toByteArray()
+
+        every { serializer.deserialize(responseBody, User::class) } returns user
+        every { transport.execute(any()) } returns HttpResponse(
+            statusCode = 200,
+            body = responseBody
+        )
+
+        val response = client.get("/Users", userId, User::class)
+
+        response.statusCode shouldBe 200
+        response.value shouldBe user
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.method shouldBe "GET"
+        requestSlot.captured.url shouldBe "$baseUrl/Users/$userId"
+    }
+
+    @Test
+    fun `replace sends PUT request and returns 200`() {
+        val userId = faker.random.randomString(10)
+        val user = User(id = userId, userName = "updated")
+        val serializedBody = """{"userName":"updated"}""".toByteArray()
+        val responseBody = """{"id":"$userId","userName":"updated"}""".toByteArray()
+
+        every { serializer.serialize(user) } returns serializedBody
+        every { serializer.deserialize(responseBody, User::class) } returns user
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 200, body = responseBody)
+
+        val response = client.replace("/Users", userId, user, User::class)
+
+        response.statusCode shouldBe 200
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.method shouldBe "PUT"
+        requestSlot.captured.url shouldBe "$baseUrl/Users/$userId"
+    }
+
+    @Test
+    fun `patch sends PATCH request with PatchRequest body`() {
+        val userId = faker.random.randomString(10)
+        val patchRequest = PatchRequest()
+        val user = User(id = userId, userName = "patched", active = true)
+        val serializedBody = """{"Operations":[]}""".toByteArray()
+        val responseBody = """{"id":"$userId"}""".toByteArray()
+
+        every { serializer.serialize(patchRequest) } returns serializedBody
+        every { serializer.deserialize(responseBody, User::class) } returns user
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 200, body = responseBody)
+
+        val response = client.patch("/Users", userId, patchRequest, User::class)
+
+        response.statusCode shouldBe 200
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.method shouldBe "PATCH"
+        requestSlot.captured.url shouldBe "$baseUrl/Users/$userId"
+        requestSlot.captured.body shouldBe serializedBody
+    }
+
+    @Test
+    fun `delete sends DELETE request and returns 204`() {
+        val userId = faker.random.randomString(10)
+
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 204)
+
+        client.delete("/Users", userId)
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.method shouldBe "DELETE"
+        requestSlot.captured.url shouldBe "$baseUrl/Users/$userId"
+    }
+
+    @Test
+    fun `search sends POST to search endpoint`() {
+        val searchRequest = SearchRequest(filter = "userName eq \"john\"", startIndex = 1, count = 10)
+        val listResponse = ListResponse<User>(totalResults = 1, resources = listOf(User(userName = "john")))
+        val serializedBody = """{"filter":"userName eq \"john\""}""".toByteArray()
+        val responseBody = """{"totalResults":1}""".toByteArray()
+
+        every { serializer.serialize(searchRequest) } returns serializedBody
+        @Suppress("UNCHECKED_CAST")
+        every { serializer.deserialize(responseBody, ListResponse::class as KClass<ListResponse<*>>) } returns listResponse
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 200, body = responseBody)
+
+        val response = client.search("/Users", searchRequest, User::class)
+
+        response.statusCode shouldBe 200
+        response.value.totalResults shouldBe 1
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.method shouldBe "POST"
+        requestSlot.captured.url shouldBe "$baseUrl/Users/.search"
+    }
+
+    @Test
+    fun `error response throws ScimClientException with ScimError`() {
+        val scimError = ScimError(
+            status = "404",
+            detail = "Resource not found"
+        )
+        val errorBody = """{"status":"404","detail":"Resource not found"}""".toByteArray()
+
+        every { serializer.deserialize(errorBody, ScimError::class) } returns scimError
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 404, body = errorBody)
+
+        val exception = shouldThrow<ScimClientException> {
+            client.get("/Users", "nonexistent", User::class)
+        }
+
+        exception.statusCode shouldBe 404
+        exception.scimError shouldNotBe null
+        exception.scimError!!.detail shouldBe "Resource not found"
+    }
+
+    @Test
+    fun `error response without parseable body throws ScimClientException`() {
+        every { serializer.deserialize(any<ByteArray>(), eq(ScimError::class)) } throws RuntimeException("parse error")
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 500, body = "Internal Error".toByteArray())
+
+        val exception = shouldThrow<ScimClientException> {
+            client.get("/Users", "123", User::class)
+        }
+
+        exception.statusCode shouldBe 500
+        exception.scimError shouldBe null
+    }
+
+    @Test
+    fun `authentication strategy is applied to requests`() {
+        val responseBody = """{"id":"123"}""".toByteArray()
+        every { serializer.deserialize(responseBody, User::class) } returns User(id = "123", userName = "test")
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 200, body = responseBody)
+
+        client.get("/Users", "123", User::class)
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.headers["Authorization"] shouldBe "Bearer test-token"
+    }
+
+    @Test
+    fun `Content-Type header is set on requests with body`() {
+        val user = User(userName = "test")
+        val serializedBody = """{"userName":"test"}""".toByteArray()
+        val responseBody = serializedBody
+
+        every { serializer.serialize(user) } returns serializedBody
+        every { serializer.deserialize(responseBody, User::class) } returns user
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 201, body = responseBody)
+
+        client.create("/Users", user, User::class)
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.headers["Content-Type"] shouldBe "application/scim+json"
+        requestSlot.captured.headers["Accept"] shouldBe "application/scim+json"
+    }
+
+    @Test
+    fun `Accept header is set on GET requests without body`() {
+        val responseBody = """{"id":"123"}""".toByteArray()
+        every { serializer.deserialize(responseBody, User::class) } returns User(id = "123", userName = "test")
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 200, body = responseBody)
+
+        client.get("/Users", "123", User::class)
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.headers["Accept"] shouldBe "application/scim+json"
+        requestSlot.captured.headers.containsKey("Content-Type") shouldBe false
+    }
+
+    @Test
+    fun `ETag and Location are extracted from response headers`() {
+        val user = User(userName = "test")
+        val serializedBody = """{}""".toByteArray()
+        val responseBody = serializedBody
+
+        every { serializer.serialize(user) } returns serializedBody
+        every { serializer.deserialize(responseBody, User::class) } returns user
+        every { transport.execute(any()) } returns HttpResponse(
+            statusCode = 201,
+            headers = mapOf(
+                "ETag" to listOf("W/\"abc\""),
+                "Location" to listOf("https://scim.example.com/Users/456")
+            ),
+            body = responseBody
+        )
+
+        val response = client.create("/Users", user, User::class)
+
+        response.etag shouldBe "W/\"abc\""
+        response.location shouldBe "https://scim.example.com/Users/456"
+    }
+
+    @Test
+    fun `getServiceProviderConfig sends GET to ServiceProviderConfig`() {
+        val config = ServiceProviderConfig()
+        val responseBody = """{}""".toByteArray()
+
+        every { serializer.deserialize(responseBody, ServiceProviderConfig::class) } returns config
+        every { transport.execute(any()) } returns HttpResponse(statusCode = 200, body = responseBody)
+
+        val response = client.getServiceProviderConfig()
+
+        response.statusCode shouldBe 200
+
+        val requestSlot = slot<HttpRequest>()
+        verify { transport.execute(capture(requestSlot)) }
+        requestSlot.captured.method shouldBe "GET"
+        requestSlot.captured.url shouldBe "$baseUrl/ServiceProviderConfig"
+    }
+
+    @Test
+    fun `close delegates to transport`() {
+        client.close()
+
+        verify { transport.close() }
+    }
+}

--- a/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/ScimClientBuilderTest.kt
+++ b/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/ScimClientBuilderTest.kt
@@ -1,0 +1,82 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.client.port.BearerTokenAuthentication
+import com.marcosbarbero.scim2.client.port.HttpRequest
+import com.marcosbarbero.scim2.client.port.HttpResponse
+import com.marcosbarbero.scim2.client.port.HttpTransport
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import io.github.serpro69.kfaker.Faker
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class ScimClientBuilderTest {
+
+    private val faker = Faker()
+
+    @Test
+    fun `build throws when baseUrl is not set`() {
+        val exception = shouldThrow<IllegalArgumentException> {
+            ScimClientBuilder()
+                .transport(mockk<HttpTransport>())
+                .serializer(mockk<ScimSerializer>())
+                .build()
+        }
+        exception.message shouldContain "baseUrl"
+    }
+
+    @Test
+    fun `build throws when transport is not set`() {
+        val exception = shouldThrow<IllegalArgumentException> {
+            ScimClientBuilder()
+                .baseUrl("https://example.com")
+                .serializer(mockk<ScimSerializer>())
+                .build()
+        }
+        exception.message shouldContain "transport"
+    }
+
+    @Test
+    fun `build throws when serializer is not set`() {
+        val exception = shouldThrow<IllegalArgumentException> {
+            ScimClientBuilder()
+                .baseUrl("https://example.com")
+                .transport(mockk<HttpTransport>())
+                .build()
+        }
+        exception.message shouldContain "serializer"
+    }
+
+    @Test
+    fun `build succeeds with all required fields`() {
+        val client = ScimClientBuilder()
+            .baseUrl("https://example.com")
+            .transport(object : HttpTransport {
+                override fun execute(request: HttpRequest): HttpResponse = HttpResponse(200)
+                override fun close() {}
+            })
+            .serializer(mockk<ScimSerializer>())
+            .build()
+
+        client shouldNotBe null
+    }
+
+    @Test
+    fun `build succeeds with optional authentication and default headers`() {
+        val token = faker.random.randomString(32)
+        val client = ScimClientBuilder()
+            .baseUrl("https://example.com")
+            .transport(object : HttpTransport {
+                override fun execute(request: HttpRequest): HttpResponse = HttpResponse(200)
+                override fun close() {}
+            })
+            .serializer(mockk<ScimSerializer>())
+            .authentication(BearerTokenAuthentication(token))
+            .defaultHeaders(mapOf("X-Tenant" to "acme"))
+            .build()
+
+        client shouldNotBe null
+    }
+}

--- a/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/port/BasicAuthenticationTest.kt
+++ b/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/port/BasicAuthenticationTest.kt
@@ -1,0 +1,53 @@
+package com.marcosbarbero.scim2.client.port
+
+import io.github.serpro69.kfaker.Faker
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.Test
+import java.util.Base64
+
+class BasicAuthenticationTest {
+
+    private val faker = Faker()
+
+    @Test
+    fun `authenticate adds Basic auth header with Base64 encoded credentials`() {
+        val username = faker.name.firstName()
+        val password = faker.random.randomString(16)
+        val auth = BasicAuthentication(username, password)
+        val request = HttpRequest(method = "GET", url = "https://example.com/Users")
+
+        val result = auth.authenticate(request)
+
+        val expected = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
+        result.headers["Authorization"] shouldBe "Basic $expected"
+    }
+
+    @Test
+    fun `authenticate preserves existing headers`() {
+        val auth = BasicAuthentication("user", "pass")
+        val request = HttpRequest(
+            method = "GET",
+            url = "https://example.com/Users",
+            headers = mapOf("Accept" to "application/json")
+        )
+
+        val result = auth.authenticate(request)
+
+        result.headers["Accept"] shouldBe "application/json"
+        result.headers["Authorization"] shouldStartWith "Basic "
+    }
+
+    @Test
+    fun `authenticate handles special characters in credentials`() {
+        val username = "user@domain.com"
+        val password = "p@ss:w0rd!"
+        val auth = BasicAuthentication(username, password)
+        val request = HttpRequest(method = "GET", url = "https://example.com/Users")
+
+        val result = auth.authenticate(request)
+
+        val decoded = String(Base64.getDecoder().decode(result.headers["Authorization"]!!.removePrefix("Basic ")))
+        decoded shouldBe "$username:$password"
+    }
+}

--- a/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/port/BearerTokenAuthenticationTest.kt
+++ b/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/port/BearerTokenAuthenticationTest.kt
@@ -1,0 +1,46 @@
+package com.marcosbarbero.scim2.client.port
+
+import io.github.serpro69.kfaker.Faker
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.Test
+
+class BearerTokenAuthenticationTest {
+
+    private val faker = Faker()
+
+    @Test
+    fun `authenticate adds Bearer token to Authorization header`() {
+        val token = faker.random.randomString(32)
+        val auth = BearerTokenAuthentication(token)
+        val request = HttpRequest(method = "GET", url = "https://example.com/Users")
+
+        val result = auth.authenticate(request)
+
+        result.headers["Authorization"] shouldBe "Bearer $token"
+    }
+
+    @Test
+    fun `authenticate preserves existing headers`() {
+        val token = faker.random.randomString(32)
+        val auth = BearerTokenAuthentication(token)
+        val existingHeaders = mapOf("X-Custom" to "value")
+        val request = HttpRequest(method = "GET", url = "https://example.com/Users", headers = existingHeaders)
+
+        val result = auth.authenticate(request)
+
+        result.headers["X-Custom"] shouldBe "value"
+        result.headers["Authorization"] shouldStartWith "Bearer "
+    }
+
+    @Test
+    fun `authenticate does not modify original request`() {
+        val token = faker.random.randomString(32)
+        val auth = BearerTokenAuthentication(token)
+        val request = HttpRequest(method = "GET", url = "https://example.com/Users")
+
+        auth.authenticate(request)
+
+        request.headers shouldBe emptyMap()
+    }
+}


### PR DESCRIPTION
## Summary
- **HttpTransport SPI** (`port/`) with `HttpRequest`/`HttpResponse` data classes and pluggable transport interface
- **AuthenticationStrategy SPI** (`port/`) with `BearerTokenAuthentication` and `BasicAuthentication` implementations
- **ScimClient interface** (`api/`) with full CRUD, search, bulk, and discovery operations plus reified Kotlin extension functions
- **DefaultScimClient** (`api/`) implementing SCIM media type headers, error parsing into `ScimClientException`, ETag/Location extraction
- **ScimClientBuilder** (`api/`) for fluent client construction with required field validation
- **JavaHttpClientTransport** (`adapter/httpclient/`) using `java.net.http.HttpClient`
- **30 tests** total (25 client + 5 transport) using MockK, Kotest assertions, kotlin-faker, and embedded HttpServer

## Test plan
- [x] `BearerTokenAuthenticationTest` — verifies Authorization header, preserves existing headers, immutability
- [x] `BasicAuthenticationTest` — verifies Base64 encoding, special characters, preserves headers
- [x] `ScimClientBuilderTest` — verifies required fields validation, successful build with all options
- [x] `DefaultScimClientTest` — POST/GET/PUT/PATCH/DELETE, search via POST .search, error handling, auth applied, headers, ETag/Location
- [x] `JavaHttpClientTransportTest` — GET/POST/DELETE via embedded HttpServer, header mapping, body transmission
- [x] `mvn clean verify` passes for both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)