### PR TITLE
feat: Spring Boot auto-configuration + starter

### DIFF
--- a/docs/adr/0020-spring-boot-autoconfiguration.md
+++ b/docs/adr/0020-spring-boot-autoconfiguration.md
@@ -1,0 +1,40 @@
+# ADR-0020: Spring Boot Auto-Configuration and Starter
+
+## Status
+
+Accepted
+
+## Context
+
+Applications using this SCIM SDK with Spring Boot need manual wiring of the dispatcher, serializer, discovery service, schema registry, and HTTP adapter. This should be automatic for Spring Boot applications while remaining fully customizable.
+
+## Decision
+
+Introduce two modules following Spring Boot's autoconfigure/starter convention:
+
+### scim2-sdk-spring-boot-autoconfigure
+
+Five auto-configuration classes, ordered by dependency:
+
+1. **ScimJacksonAutoConfiguration** - Registers `ScimModule` into Jackson's `ObjectMapper` and provides a `JacksonScimSerializer` bean. Activates when `ObjectMapper` and `ScimModule` are on the classpath.
+
+2. **ScimServerAutoConfiguration** - Wires `ScimServerConfig` from `ScimProperties` (`@ConfigurationProperties(prefix = "scim")`), creates `SchemaRegistry` (auto-registers resource types from all `ResourceHandler` beans), `DiscoveryService`, and `ScimEndpointDispatcher`. Optional beans (`BulkHandler`, `MeHandler`, `IdentityResolver`, `AuthorizationEvaluator`, `ScimEventPublisher`, `ScimMetrics`, `ScimTracer`, `ScimInterceptor`) are injected via `ObjectProvider` with graceful fallbacks.
+
+3. **ScimClientAutoConfiguration** - Creates `HttpTransport` (defaults to `JavaHttpClientTransport`) and `ScimClient` when `scim.client.base-url` is set. Optional `AuthenticationStrategy` bean is auto-detected.
+
+4. **ScimWebAutoConfiguration** - Registers `ScimController` (Spring MVC adapter mapping `${scim.base-path}/**` to `ScimEndpointDispatcher`) and `ScimExceptionHandler` (`@ControllerAdvice` converting `ScimException` to SCIM JSON error responses). Only activates in servlet web applications.
+
+5. **ScimObservabilityAutoConfiguration** - Provides `MicrometerScimMetrics` (adapting `ScimMetrics` to Micrometer's `MeterRegistry`) when Micrometer is on the classpath.
+
+All auto-configurations use `@ConditionalOnMissingBean` for full back-off support.
+
+### scim2-sdk-spring-boot-starter
+
+Empty JAR aggregating transitive dependencies: autoconfigure, server, client, client-httpclient, and `spring-boot-starter`.
+
+## Consequences
+
+- Spring Boot users add one dependency (`scim2-sdk-spring-boot-starter`) and implement `ResourceHandler` beans
+- All beans back off when custom implementations are provided
+- Non-Spring applications are unaffected (no framework dependency in core/server)
+- Configuration is externalized via `application.properties`/`application.yml` under the `scim.*` prefix

--- a/scim2-sdk-spring-boot-autoconfigure/pom.xml
+++ b/scim2-sdk-spring-boot-autoconfigure/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>com.marcosbarbero</groupId>
+            <artifactId>scim2-sdk-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.marcosbarbero</groupId>
             <artifactId>scim2-sdk-server</artifactId>
             <optional>true</optional>
         </dependency>
@@ -28,9 +33,13 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.marcosbarbero</groupId>
+            <artifactId>scim2-sdk-client-httpclient</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -41,6 +50,53 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.serpro69</groupId>
+            <artifactId>kotlin-faker</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimClientAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimClientAutoConfiguration.kt
@@ -1,0 +1,40 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.client.adapter.httpclient.JavaHttpClientTransport
+import com.marcosbarbero.scim2.client.api.ScimClient
+import com.marcosbarbero.scim2.client.api.ScimClientBuilder
+import com.marcosbarbero.scim2.client.port.AuthenticationStrategy
+import com.marcosbarbero.scim2.client.port.HttpTransport
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration(after = [ScimJacksonAutoConfiguration::class])
+@ConditionalOnClass(ScimClient::class)
+@ConditionalOnProperty(prefix = "scim.client", name = ["base-url"])
+@EnableConfigurationProperties(ScimProperties::class)
+class ScimClientAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(HttpTransport::class)
+    fun httpTransport(): HttpTransport = JavaHttpClientTransport()
+
+    @Bean
+    @ConditionalOnMissingBean(ScimClient::class)
+    fun scimClient(
+        transport: HttpTransport,
+        serializer: ScimSerializer,
+        properties: ScimProperties,
+        authentication: ObjectProvider<AuthenticationStrategy>
+    ): ScimClient = ScimClientBuilder()
+        .baseUrl(properties.client.baseUrl!!)
+        .transport(transport)
+        .serializer(serializer)
+        .apply { authentication.ifAvailable?.let { authentication(it) } }
+        .build()
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimJacksonAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimJacksonAutoConfiguration.kt
@@ -1,0 +1,25 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
+import com.marcosbarbero.scim2.core.serialization.jackson.ScimModule
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration(after = [JacksonAutoConfiguration::class])
+@ConditionalOnClass(ObjectMapper::class, ScimModule::class)
+class ScimJacksonAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun scimModule(): ScimModule = ScimModule()
+
+    @Bean
+    @ConditionalOnMissingBean(ScimSerializer::class)
+    fun scimSerializer(objectMapper: ObjectMapper): ScimSerializer =
+        JacksonScimSerializer(objectMapper)
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimObservabilityAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimObservabilityAutoConfiguration.kt
@@ -1,0 +1,21 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.core.observability.ScimMetrics
+import com.marcosbarbero.scim2.spring.observability.MicrometerScimMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration(after = [ScimServerAutoConfiguration::class])
+@ConditionalOnClass(MeterRegistry::class)
+class ScimObservabilityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(MeterRegistry::class)
+    @ConditionalOnMissingBean(ScimMetrics::class)
+    fun micrometerScimMetrics(registry: MeterRegistry): ScimMetrics =
+        MicrometerScimMetrics(registry)
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProperties.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProperties.kt
@@ -1,0 +1,54 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "scim")
+data class ScimProperties(
+    val basePath: String = "/scim/v2",
+    val bulk: BulkProperties = BulkProperties(),
+    val filter: FilterProperties = FilterProperties(),
+    val sort: SortProperties = SortProperties(),
+    val etag: EtagProperties = EtagProperties(),
+    val changePassword: ChangePasswordProperties = ChangePasswordProperties(),
+    val patch: PatchProperties = PatchProperties(),
+    val pagination: PaginationProperties = PaginationProperties(),
+    val client: ClientProperties = ClientProperties()
+) {
+    data class BulkProperties(
+        val enabled: Boolean = true,
+        val maxOperations: Int = 1000,
+        val maxPayloadSize: Long = 1_048_576
+    )
+
+    data class FilterProperties(
+        val enabled: Boolean = true,
+        val maxResults: Int = 200
+    )
+
+    data class SortProperties(
+        val enabled: Boolean = false
+    )
+
+    data class EtagProperties(
+        val enabled: Boolean = true
+    )
+
+    data class ChangePasswordProperties(
+        val enabled: Boolean = false
+    )
+
+    data class PatchProperties(
+        val enabled: Boolean = true
+    )
+
+    data class PaginationProperties(
+        val defaultPageSize: Int = 100,
+        val maxPageSize: Int = 1000
+    )
+
+    data class ClientProperties(
+        val baseUrl: String? = null,
+        val connectTimeout: java.time.Duration = java.time.Duration.ofSeconds(10),
+        val readTimeout: java.time.Duration = java.time.Duration.ofSeconds(30)
+    )
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimServerAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimServerAutoConfiguration.kt
@@ -1,0 +1,98 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.marcosbarbero.scim2.core.event.ScimEventPublisher
+import com.marcosbarbero.scim2.core.observability.ScimMetrics
+import com.marcosbarbero.scim2.core.observability.ScimTracer
+import com.marcosbarbero.scim2.core.schema.introspector.SchemaRegistry
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import com.marcosbarbero.scim2.server.adapter.discovery.DiscoveryService
+import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
+import com.marcosbarbero.scim2.server.config.ScimServerConfig
+import com.marcosbarbero.scim2.server.interceptor.ScimInterceptor
+import com.marcosbarbero.scim2.server.port.AuthorizationEvaluator
+import com.marcosbarbero.scim2.server.port.BulkHandler
+import com.marcosbarbero.scim2.server.port.IdentityResolver
+import com.marcosbarbero.scim2.server.port.MeHandler
+import com.marcosbarbero.scim2.server.port.ResourceHandler
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration(after = [ScimJacksonAutoConfiguration::class])
+@ConditionalOnClass(ScimEndpointDispatcher::class)
+@EnableConfigurationProperties(ScimProperties::class)
+class ScimServerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun scimServerConfig(properties: ScimProperties): ScimServerConfig = ScimServerConfig(
+        basePath = properties.basePath,
+        bulkEnabled = properties.bulk.enabled,
+        bulkMaxOperations = properties.bulk.maxOperations,
+        bulkMaxPayloadSize = properties.bulk.maxPayloadSize,
+        filterEnabled = properties.filter.enabled,
+        filterMaxResults = properties.filter.maxResults,
+        sortEnabled = properties.sort.enabled,
+        etagEnabled = properties.etag.enabled,
+        changePasswordEnabled = properties.changePassword.enabled,
+        patchEnabled = properties.patch.enabled,
+        defaultPageSize = properties.pagination.defaultPageSize,
+        maxPageSize = properties.pagination.maxPageSize
+    )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun schemaRegistry(handlers: ObjectProvider<ResourceHandler<*>>): SchemaRegistry {
+        val registry = SchemaRegistry()
+        handlers.orderedStream().forEach { handler ->
+            registry.register(handler.resourceType.kotlin)
+        }
+        return registry
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun discoveryService(
+        handlers: ObjectProvider<ResourceHandler<*>>,
+        schemaRegistry: SchemaRegistry,
+        config: ScimServerConfig
+    ): DiscoveryService = DiscoveryService(
+        handlers = handlers.orderedStream().toList(),
+        schemaRegistry = schemaRegistry,
+        config = config
+    )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun scimEndpointDispatcher(
+        handlers: ObjectProvider<ResourceHandler<*>>,
+        discoveryService: DiscoveryService,
+        config: ScimServerConfig,
+        serializer: ScimSerializer,
+        interceptors: ObjectProvider<ScimInterceptor>,
+        bulkHandler: ObjectProvider<BulkHandler>,
+        meHandler: ObjectProvider<MeHandler<*>>,
+        identityResolver: ObjectProvider<IdentityResolver>,
+        authorizationEvaluator: ObjectProvider<AuthorizationEvaluator>,
+        eventPublisher: ObjectProvider<ScimEventPublisher>,
+        metrics: ObjectProvider<ScimMetrics>,
+        tracer: ObjectProvider<ScimTracer>
+    ): ScimEndpointDispatcher = ScimEndpointDispatcher(
+        handlers = handlers.orderedStream().toList(),
+        bulkHandler = bulkHandler.ifAvailable,
+        meHandler = meHandler.ifAvailable,
+        discoveryService = discoveryService,
+        config = config,
+        serializer = serializer,
+        interceptors = interceptors.orderedStream().toList(),
+        identityResolver = identityResolver.ifAvailable,
+        authorizationEvaluator = authorizationEvaluator.ifAvailable,
+        eventPublisher = eventPublisher.ifAvailable ?: com.marcosbarbero.scim2.core.event.NoOpEventPublisher,
+        metrics = metrics.ifAvailable ?: com.marcosbarbero.scim2.core.observability.NoOpScimMetrics,
+        tracer = tracer.ifAvailable ?: com.marcosbarbero.scim2.core.observability.NoOpScimTracer
+    )
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimWebAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimWebAutoConfiguration.kt
@@ -1,0 +1,30 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
+import com.marcosbarbero.scim2.spring.web.ScimController
+import com.marcosbarbero.scim2.spring.web.ScimExceptionHandler
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration(after = [ScimServerAutoConfiguration::class])
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass(HttpServletRequest::class, ScimEndpointDispatcher::class)
+@ConditionalOnBean(ScimEndpointDispatcher::class)
+class ScimWebAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun scimController(dispatcher: ScimEndpointDispatcher): ScimController =
+        ScimController(dispatcher)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun scimExceptionHandler(serializer: ScimSerializer): ScimExceptionHandler =
+        ScimExceptionHandler(serializer)
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/observability/MicrometerScimMetrics.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/observability/MicrometerScimMetrics.kt
@@ -1,0 +1,70 @@
+package com.marcosbarbero.scim2.spring.observability
+
+import com.marcosbarbero.scim2.core.observability.ScimMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicLong
+
+class MicrometerScimMetrics(private val registry: MeterRegistry) : ScimMetrics {
+
+    private val activeGauges = mutableMapOf<String, AtomicLong>()
+
+    override fun recordOperation(endpoint: String, method: String, status: Int, duration: Duration) {
+        registry.timer(
+            "scim.request.duration",
+            "endpoint", endpoint,
+            "method", method,
+            "status", status.toString()
+        ).record(duration)
+    }
+
+    override fun recordFilterParse(duration: Duration, success: Boolean) {
+        registry.timer(
+            "scim.filter.parse.duration",
+            "success", success.toString()
+        ).record(duration)
+    }
+
+    override fun recordPatchOperations(endpoint: String, operationCount: Int, duration: Duration) {
+        registry.timer(
+            "scim.patch.duration",
+            "endpoint", endpoint
+        ).record(duration)
+        registry.counter(
+            "scim.patch.operations",
+            "endpoint", endpoint
+        ).increment(operationCount.toDouble())
+    }
+
+    override fun recordBulkOperation(operationCount: Int, failureCount: Int, duration: Duration) {
+        registry.timer("scim.bulk.duration").record(duration)
+        registry.counter("scim.bulk.operations").increment(operationCount.toDouble())
+        registry.counter("scim.bulk.failures").increment(failureCount.toDouble())
+    }
+
+    override fun recordSearchResults(endpoint: String, totalResults: Int, duration: Duration) {
+        registry.timer(
+            "scim.search.duration",
+            "endpoint", endpoint
+        ).record(duration)
+        registry.summary(
+            "scim.search.results",
+            "endpoint", endpoint
+        ).record(totalResults.toDouble())
+    }
+
+    override fun incrementActiveRequests(endpoint: String) {
+        getOrCreateGauge(endpoint).incrementAndGet()
+    }
+
+    override fun decrementActiveRequests(endpoint: String) {
+        getOrCreateGauge(endpoint).decrementAndGet()
+    }
+
+    private fun getOrCreateGauge(endpoint: String): AtomicLong =
+        activeGauges.computeIfAbsent(endpoint) { ep ->
+            val gauge = AtomicLong(0)
+            registry.gauge("scim.request.active", listOf(io.micrometer.core.instrument.Tag.of("endpoint", ep)), gauge) { it.toDouble() }
+            gauge
+        }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/web/ScimController.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/web/ScimController.kt
@@ -1,0 +1,56 @@
+package com.marcosbarbero.scim2.spring.web
+
+import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import com.marcosbarbero.scim2.server.http.ScimHttpResponse
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("\${scim.base-path:/scim/v2}")
+class ScimController(private val dispatcher: ScimEndpointDispatcher) {
+
+    @RequestMapping("/**")
+    fun handle(request: HttpServletRequest): ResponseEntity<ByteArray> {
+        val scimRequest = toScimHttpRequest(request)
+        val scimResponse = dispatcher.dispatch(scimRequest)
+        return toResponseEntity(scimResponse)
+    }
+
+    private fun toScimHttpRequest(request: HttpServletRequest): ScimHttpRequest {
+        val method = HttpMethod.valueOf(request.method.uppercase())
+        val path = request.requestURI
+        val headers = mutableMapOf<String, List<String>>()
+        val headerNames = request.headerNames
+        while (headerNames.hasMoreElements()) {
+            val name = headerNames.nextElement()
+            headers[name] = request.getHeaders(name).toList()
+        }
+        val queryParameters = mutableMapOf<String, List<String>>()
+        request.parameterMap.forEach { (key, values) ->
+            queryParameters[key] = values.toList()
+        }
+        val body = request.inputStream.readAllBytes().takeIf { it.isNotEmpty() }
+
+        return ScimHttpRequest(
+            method = method,
+            path = path,
+            headers = headers,
+            queryParameters = queryParameters,
+            body = body
+        )
+    }
+
+    private fun toResponseEntity(response: ScimHttpResponse): ResponseEntity<ByteArray> {
+        val headers = HttpHeaders()
+        response.headers.forEach { (key, value) -> headers.add(key, value) }
+        return ResponseEntity
+            .status(response.status)
+            .headers(headers)
+            .body(response.body)
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/web/ScimExceptionHandler.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/web/ScimExceptionHandler.kt
@@ -1,0 +1,21 @@
+package com.marcosbarbero.scim2.spring.web
+
+import com.marcosbarbero.scim2.core.domain.model.error.ScimException
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class ScimExceptionHandler(private val serializer: ScimSerializer) {
+
+    @ExceptionHandler(ScimException::class)
+    fun handleScimException(ex: ScimException): ResponseEntity<ByteArray> {
+        val error = ex.toScimError()
+        val body = serializer.serialize(error)
+        return ResponseEntity.status(ex.status)
+            .contentType(MediaType("application", "scim+json"))
+            .body(body)
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,5 @@
+com.marcosbarbero.scim2.spring.autoconfigure.ScimJacksonAutoConfiguration
+com.marcosbarbero.scim2.spring.autoconfigure.ScimServerAutoConfiguration
+com.marcosbarbero.scim2.spring.autoconfigure.ScimClientAutoConfiguration
+com.marcosbarbero.scim2.spring.autoconfigure.ScimWebAutoConfiguration
+com.marcosbarbero.scim2.spring.autoconfigure.ScimObservabilityAutoConfiguration

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimClientAutoConfigurationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimClientAutoConfigurationTest.kt
@@ -1,0 +1,65 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.client.api.ScimClient
+import com.marcosbarbero.scim2.client.port.HttpTransport
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class ScimClientAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                JacksonAutoConfiguration::class.java,
+                ScimJacksonAutoConfiguration::class.java,
+                ScimClientAutoConfiguration::class.java
+            )
+        )
+
+    @Test
+    fun `auto-configures client when base-url is set`() {
+        contextRunner
+            .withPropertyValues("scim.client.base-url=http://localhost:8080/scim/v2")
+            .run { context ->
+                context.getBean(HttpTransport::class.java).shouldNotBeNull()
+                context.getBean(ScimClient::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `no client without base-url property`() {
+        contextRunner
+            .run { context ->
+                context.containsBean("scimClient").shouldBeFalse()
+                context.containsBean("httpTransport").shouldBeFalse()
+            }
+    }
+
+    @Test
+    fun `backs off when custom ScimClient provided`() {
+        val customClient = mockk<ScimClient>()
+        contextRunner
+            .withPropertyValues("scim.client.base-url=http://localhost:8080/scim/v2")
+            .withBean("customClient", ScimClient::class.java, { customClient })
+            .run { context ->
+                context.getBean(ScimClient::class.java) shouldBe customClient
+            }
+    }
+
+    @Test
+    fun `backs off when custom HttpTransport provided`() {
+        val customTransport = mockk<HttpTransport>()
+        contextRunner
+            .withPropertyValues("scim.client.base-url=http://localhost:8080/scim/v2")
+            .withBean("customTransport", HttpTransport::class.java, { customTransport })
+            .run { context ->
+                context.getBean(HttpTransport::class.java) shouldBe customTransport
+            }
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimJacksonAutoConfigurationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimJacksonAutoConfigurationTest.kt
@@ -1,0 +1,41 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class ScimJacksonAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                JacksonAutoConfiguration::class.java,
+                ScimJacksonAutoConfiguration::class.java
+            )
+        )
+
+    @Test
+    fun `auto-configures ScimSerializer with Jackson`() {
+        contextRunner.run { context ->
+            val serializer = context.getBean(ScimSerializer::class.java)
+            serializer.shouldNotBeNull()
+            serializer.shouldBeInstanceOf<JacksonScimSerializer>()
+        }
+    }
+
+    @Test
+    fun `backs off when custom ScimSerializer provided`() {
+        val custom = JacksonScimSerializer()
+        contextRunner
+            .withBean("customSerializer", ScimSerializer::class.java, { custom })
+            .run { context ->
+                context.getBean(ScimSerializer::class.java) shouldBe custom
+            }
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimServerAutoConfigurationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimServerAutoConfigurationTest.kt
@@ -1,0 +1,125 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
+import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+import com.marcosbarbero.scim2.core.domain.vo.ETag
+import com.marcosbarbero.scim2.core.domain.vo.ResourceId
+import com.marcosbarbero.scim2.core.schema.introspector.SchemaRegistry
+import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import com.marcosbarbero.scim2.server.adapter.discovery.DiscoveryService
+import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
+import com.marcosbarbero.scim2.server.config.ScimServerConfig
+import com.marcosbarbero.scim2.server.port.ResourceHandler
+import com.marcosbarbero.scim2.server.port.ScimRequestContext
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class ScimServerAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                JacksonAutoConfiguration::class.java,
+                ScimJacksonAutoConfiguration::class.java,
+                ScimServerAutoConfiguration::class.java
+            )
+        )
+
+    @Test
+    fun `auto-configures server beans when ResourceHandler is present`() {
+        contextRunner
+            .withBean(TestUserHandler::class.java)
+            .run { context ->
+                context.getBean(ScimServerConfig::class.java).shouldNotBeNull()
+                context.getBean(SchemaRegistry::class.java).shouldNotBeNull()
+                context.getBean(DiscoveryService::class.java).shouldNotBeNull()
+                context.getBean(ScimEndpointDispatcher::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `maps properties to ScimServerConfig`() {
+        contextRunner
+            .withPropertyValues(
+                "scim.base-path=/api/scim",
+                "scim.bulk.enabled=false",
+                "scim.bulk.max-operations=500",
+                "scim.filter.max-results=50",
+                "scim.sort.enabled=true",
+                "scim.etag.enabled=false",
+                "scim.patch.enabled=false",
+                "scim.pagination.default-page-size=25",
+                "scim.pagination.max-page-size=200"
+            )
+            .withBean(TestUserHandler::class.java)
+            .run { context ->
+                val config = context.getBean(ScimServerConfig::class.java)
+                config.basePath shouldBe "/api/scim"
+                config.bulkEnabled shouldBe false
+                config.bulkMaxOperations shouldBe 500
+                config.filterMaxResults shouldBe 50
+                config.sortEnabled shouldBe true
+                config.etagEnabled shouldBe false
+                config.patchEnabled shouldBe false
+                config.defaultPageSize shouldBe 25
+                config.maxPageSize shouldBe 200
+            }
+    }
+
+    @Test
+    fun `backs off when custom ScimServerConfig provided`() {
+        val customConfig = ScimServerConfig(basePath = "/custom")
+        contextRunner
+            .withBean(TestUserHandler::class.java)
+            .withBean("customConfig", ScimServerConfig::class.java, { customConfig })
+            .run { context ->
+                context.getBean(ScimServerConfig::class.java).basePath shouldBe "/custom"
+            }
+    }
+
+    @Test
+    fun `backs off when custom ScimSerializer provided`() {
+        contextRunner
+            .withBean(TestUserHandler::class.java)
+            .withBean("customSerializer", ScimSerializer::class.java, { JacksonScimSerializer() })
+            .run { context ->
+                context.getBean(ScimSerializer::class.java).shouldBeInstanceOf<JacksonScimSerializer>()
+            }
+    }
+
+    @Test
+    fun `creates dispatcher even without ResourceHandler`() {
+        contextRunner
+            .run { context ->
+                context.getBean(ScimEndpointDispatcher::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `registers ScimModule bean`() {
+        contextRunner
+            .run { context ->
+                context.getBean(com.marcosbarbero.scim2.core.serialization.jackson.ScimModule::class.java).shouldNotBeNull()
+            }
+    }
+
+    private class TestUserHandler : ResourceHandler<User> {
+        override val resourceType: Class<User> = User::class.java
+        override val endpoint: String = "/Users"
+        override fun get(id: ResourceId, context: ScimRequestContext): User = throw UnsupportedOperationException()
+        override fun create(resource: User, context: ScimRequestContext): User = throw UnsupportedOperationException()
+        override fun replace(id: ResourceId, resource: User, version: ETag?, context: ScimRequestContext): User = throw UnsupportedOperationException()
+        override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): User = throw UnsupportedOperationException()
+        override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) = throw UnsupportedOperationException()
+        override fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<User> = throw UnsupportedOperationException()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ScimJacksonAutoConfiguration` - registers `ScimModule` into Jackson's `ObjectMapper`, provides `JacksonScimSerializer` bean
- Add `ScimServerAutoConfiguration` - wires `ScimServerConfig` from `ScimProperties`, auto-creates `SchemaRegistry`, `DiscoveryService`, and `ScimEndpointDispatcher` with optional SPI beans via `ObjectProvider`
- Add `ScimClientAutoConfiguration` - creates `HttpTransport` and `ScimClient` when `scim.client.base-url` is set
- Add `ScimWebAutoConfiguration` - registers `ScimController` (Spring MVC adapter) and `ScimExceptionHandler` (`@ControllerAdvice`) for servlet web applications
- Add `ScimObservabilityAutoConfiguration` with `MicrometerScimMetrics` adapter when Micrometer is on the classpath
- Add `ScimProperties` with `@ConfigurationProperties(prefix = "scim")` mapping all server/client config
- Add `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
- Starter module aggregates all transitive dependencies (already existed as empty JAR)
- Add ADR-0020

## Test plan
- [x] `ScimServerAutoConfigurationTest` - 6 tests: bean creation, property mapping, back-off on custom beans
- [x] `ScimClientAutoConfigurationTest` - 4 tests: client creation with base-url, no client without property, back-off
- [x] `ScimJacksonAutoConfigurationTest` - 2 tests: serializer creation, back-off
- [x] Full build passes (all 12 autoconfigure tests + all other module tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)