### PR TITLE
feat: RFC 9457 ProblemDetail support with content negotiation

### DIFF
--- a/docs/adr/0019-catch-all-scim-controller.md
+++ b/docs/adr/0019-catch-all-scim-controller.md
@@ -1,0 +1,26 @@
+# ADR-0019: Catch-All SCIM Controller
+
+## Status
+Accepted
+
+## Context
+The Spring Boot auto-configuration needs to expose SCIM endpoints. Two approaches were considered:
+1. **Explicit controllers**: Separate `@RestController` per endpoint type (ScimUserController, ScimGroupController, ScimDiscoveryController, ScimBulkController)
+2. **Catch-all controller**: Single `ScimController` with `@RequestMapping("/**")` under the SCIM base path, delegating all routing to `ScimEndpointDispatcher`
+
+## Decision
+Use the catch-all controller approach.
+
+The `ScimController` is a thin Spring MVC adapter that bridges `HttpServletRequest` to `ScimHttpRequest`, delegates to `ScimEndpointDispatcher`, and maps `ScimHttpResponse` back to `ResponseEntity`. All routing logic lives in the framework-agnostic dispatcher.
+
+## Consequences
+**Benefits:**
+- The routing logic is in `ScimEndpointDispatcher` (framework-agnostic), not in Spring annotations — keeps the server module portable
+- Custom resource types (e.g., `/Employees`, `/Devices`) are automatically handled without new controllers
+- Case-insensitive routing is handled once in the dispatcher, not per-controller
+- Single point of entry for interceptors, metrics, tracing, and event publishing
+
+**Trade-offs:**
+- Less visibility in Spring Boot Actuator's endpoint mapping (shows as single `/**` pattern)
+- Swagger/OpenAPI auto-generation doesn't see individual endpoints (manual OpenAPI spec recommended)
+- Spring Security `requestMatchers` must use path patterns rather than controller-specific rules

--- a/docs/adr/0021-rfc9457-problemdetail.md
+++ b/docs/adr/0021-rfc9457-problemdetail.md
@@ -1,0 +1,24 @@
+# ADR-0021: RFC 9457 ProblemDetail Support
+
+## Status
+Accepted
+
+## Context
+SCIM 2.0 (RFC 7644) defines its own error format (`urn:ietf:params:scim:api:messages:2.0:Error`). However, RFC 9457 (Problem Details for HTTP APIs) has become the industry standard for HTTP API error responses. Many API consumers and tooling (including Spring Boot 3.x) expect ProblemDetail format.
+
+## Decision
+Support both error formats via content negotiation:
+- `Accept: application/problem+json` → respond with RFC 9457 ProblemDetail
+- `Accept: application/scim+json` (or default) → respond with SCIM Error format
+
+The `ScimProblemDetail` type maps SCIM error fields to ProblemDetail:
+- `scimType` → `type` URI (prefixed with `urn:ietf:params:scim:api:messages:2.0:Error:`)
+- `status` → `status`
+- `detail` → `detail`
+- SCIM's `scimType` also preserved as an extension field for backwards compatibility
+
+## Consequences
+- Clients can choose their preferred error format via Accept header
+- Spring Boot's native ProblemDetail support aligns naturally
+- SCIM-specific error information is never lost
+- Slight complexity in error handling (two formats), but contained in one place

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimException.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimException.kt
@@ -14,6 +14,8 @@ open class ScimException(
         scimType = scimType?.value,
         detail = detail
     )
+
+    fun toScimProblemDetail(): ScimProblemDetail = ScimProblemDetail.fromScimException(this)
 }
 
 class ResourceNotFoundException(detail: String? = null) :

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimProblemDetail.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimProblemDetail.kt
@@ -1,0 +1,56 @@
+package com.marcosbarbero.scim2.core.domain.model.error
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * RFC 9457 Problem Detail representation, extended with SCIM-specific fields.
+ *
+ * When Content-Type is application/problem+json, this format is used.
+ * When Content-Type is application/scim+json, the standard ScimError format is used.
+ * Both carry the same information.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ScimProblemDetail(
+    val type: String = "about:blank",
+    val title: String? = null,
+    val status: Int,
+    val detail: String? = null,
+    val instance: String? = null,
+    @JsonProperty("scimType")
+    val scimType: String? = null
+) {
+    companion object {
+        private const val SCIM_ERROR_TYPE_PREFIX = "urn:ietf:params:scim:api:messages:2.0:Error:"
+
+        fun fromScimException(ex: ScimException): ScimProblemDetail = ScimProblemDetail(
+            type = ex.scimType?.let { "$SCIM_ERROR_TYPE_PREFIX${it.value}" } ?: "about:blank",
+            title = ex.scimType?.name?.replace("_", " ")?.lowercase()?.replaceFirstChar { it.uppercase() }
+                ?: httpStatusTitle(ex.status),
+            status = ex.status,
+            detail = ex.detail,
+            scimType = ex.scimType?.value
+        )
+
+        fun fromScimError(error: ScimError): ScimProblemDetail = ScimProblemDetail(
+            type = error.scimType?.let { "$SCIM_ERROR_TYPE_PREFIX$it" } ?: "about:blank",
+            title = error.scimType ?: httpStatusTitle(error.status.toIntOrNull() ?: 500),
+            status = error.status.toIntOrNull() ?: 500,
+            detail = error.detail,
+            scimType = error.scimType
+        )
+
+        internal fun httpStatusTitle(status: Int): String = when (status) {
+            400 -> "Bad Request"
+            401 -> "Unauthorized"
+            403 -> "Forbidden"
+            404 -> "Not Found"
+            409 -> "Conflict"
+            412 -> "Precondition Failed"
+            413 -> "Payload Too Large"
+            500 -> "Internal Server Error"
+            501 -> "Not Implemented"
+            else -> "Error"
+        }
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimProblemDetailTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimProblemDetailTest.kt
@@ -1,0 +1,197 @@
+package com.marcosbarbero.scim2.core.domain.model.error
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.github.serpro69.kfaker.Faker
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ScimProblemDetailTest {
+
+    private val faker = Faker()
+    private val mapper = jacksonObjectMapper()
+
+    @Nested
+    inner class FromScimExceptionTest {
+
+        @Test
+        fun `fromScimException maps all fields correctly`() {
+            val detail = faker.name.name()
+            val ex = InvalidFilterException(detail)
+
+            val problemDetail = ScimProblemDetail.fromScimException(ex)
+
+            problemDetail.status shouldBe 400
+            problemDetail.detail shouldBe detail
+            problemDetail.scimType shouldBe "invalidFilter"
+            problemDetail.type shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:invalidFilter"
+            problemDetail.title shouldBe "Invalid filter"
+            problemDetail.instance shouldBe null
+        }
+
+        @Test
+        fun `fromScimException with scimType generates type URI`() {
+            val ex = ResourceConflictException("duplicate")
+
+            val problemDetail = ScimProblemDetail.fromScimException(ex)
+
+            problemDetail.type shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:uniqueness"
+            problemDetail.scimType shouldBe "uniqueness"
+            problemDetail.title shouldBe "Uniqueness"
+        }
+
+        @Test
+        fun `fromScimException without scimType uses about blank`() {
+            val detail = faker.name.name()
+            val ex = ResourceNotFoundException(detail)
+
+            val problemDetail = ScimProblemDetail.fromScimException(ex)
+
+            problemDetail.type shouldBe "about:blank"
+            problemDetail.scimType shouldBe null
+            problemDetail.title shouldBe "Not Found"
+            problemDetail.status shouldBe 404
+            problemDetail.detail shouldBe detail
+        }
+
+        @Test
+        fun `toScimProblemDetail on ScimException delegates to fromScimException`() {
+            val detail = faker.name.name()
+            val ex = InvalidSyntaxException(detail)
+
+            val problemDetail = ex.toScimProblemDetail()
+
+            problemDetail.status shouldBe 400
+            problemDetail.scimType shouldBe "invalidSyntax"
+            problemDetail.type shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:invalidSyntax"
+        }
+    }
+
+    @Nested
+    inner class FromScimErrorTest {
+
+        @Test
+        fun `fromScimError round-trip preserves fields`() {
+            val detail = faker.name.name()
+            val error = ScimError(
+                status = "409",
+                scimType = "uniqueness",
+                detail = detail
+            )
+
+            val problemDetail = ScimProblemDetail.fromScimError(error)
+
+            problemDetail.status shouldBe 409
+            problemDetail.scimType shouldBe "uniqueness"
+            problemDetail.detail shouldBe detail
+            problemDetail.type shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:uniqueness"
+            problemDetail.title shouldBe "uniqueness"
+        }
+
+        @Test
+        fun `fromScimError without scimType uses about blank`() {
+            val error = ScimError(
+                status = "404",
+                detail = "Resource not found"
+            )
+
+            val problemDetail = ScimProblemDetail.fromScimError(error)
+
+            problemDetail.type shouldBe "about:blank"
+            problemDetail.title shouldBe "Not Found"
+            problemDetail.scimType shouldBe null
+        }
+
+        @Test
+        fun `fromScimError with invalid status defaults to 500`() {
+            val error = ScimError(
+                status = "invalid",
+                detail = "Something went wrong"
+            )
+
+            val problemDetail = ScimProblemDetail.fromScimError(error)
+
+            problemDetail.status shouldBe 500
+            problemDetail.title shouldBe "Internal Server Error"
+        }
+    }
+
+    @Nested
+    inner class HttpStatusTitleTest {
+
+        @Test
+        fun `httpStatusTitle maps common codes`() {
+            ScimProblemDetail.httpStatusTitle(400) shouldBe "Bad Request"
+            ScimProblemDetail.httpStatusTitle(401) shouldBe "Unauthorized"
+            ScimProblemDetail.httpStatusTitle(403) shouldBe "Forbidden"
+            ScimProblemDetail.httpStatusTitle(404) shouldBe "Not Found"
+            ScimProblemDetail.httpStatusTitle(409) shouldBe "Conflict"
+            ScimProblemDetail.httpStatusTitle(412) shouldBe "Precondition Failed"
+            ScimProblemDetail.httpStatusTitle(413) shouldBe "Payload Too Large"
+            ScimProblemDetail.httpStatusTitle(500) shouldBe "Internal Server Error"
+            ScimProblemDetail.httpStatusTitle(501) shouldBe "Not Implemented"
+            ScimProblemDetail.httpStatusTitle(418) shouldBe "Error"
+        }
+    }
+
+    @Nested
+    inner class JsonSerializationTest {
+
+        @Test
+        fun `JSON serialization includes non-null fields only`() {
+            val problemDetail = ScimProblemDetail(
+                status = 404,
+                detail = "User not found",
+                title = "Not Found"
+            )
+
+            val json = mapper.writeValueAsString(problemDetail)
+            val tree = mapper.readTree(json)
+
+            tree.has("status") shouldBe true
+            tree.has("detail") shouldBe true
+            tree.has("title") shouldBe true
+            tree.has("type") shouldBe true
+            tree.get("type").asText() shouldBe "about:blank"
+            // null fields should be absent
+            tree.has("instance") shouldBe false
+            tree.has("scimType") shouldBe false
+        }
+
+        @Test
+        fun `JSON serialization includes scimType when present`() {
+            val problemDetail = ScimProblemDetail(
+                type = "urn:ietf:params:scim:api:messages:2.0:Error:invalidFilter",
+                status = 400,
+                detail = "Bad filter",
+                title = "Invalid filter",
+                scimType = "invalidFilter"
+            )
+
+            val json = mapper.writeValueAsString(problemDetail)
+            val tree = mapper.readTree(json)
+
+            tree.get("scimType").asText() shouldBe "invalidFilter"
+            tree.get("type").asText() shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:invalidFilter"
+        }
+
+        @Test
+        fun `JSON round-trip deserialization preserves all fields`() {
+            val original = ScimProblemDetail(
+                type = "urn:ietf:params:scim:api:messages:2.0:Error:uniqueness",
+                title = "Uniqueness",
+                status = 409,
+                detail = "User already exists",
+                instance = "/Users/123",
+                scimType = "uniqueness"
+            )
+
+            val json = mapper.writeValueAsString(original)
+            val deserialized = mapper.readValue<ScimProblemDetail>(json)
+
+            deserialized shouldBe original
+        }
+    }
+}

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcher.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcher.kt
@@ -86,17 +86,11 @@ class ScimEndpointDispatcher(
                 val processedException = sortedInterceptors.fold(e) { ex, interceptor ->
                     interceptor.onError(processedRequest, ex, context)
                 }
-                val errorBody = serializer.serialize(processedException.toScimError())
-                ScimHttpResponse.error(processedException.status, errorBody)
+                buildErrorResponse(processedException, processedRequest)
             } catch (e: Exception) {
                 logger.error("Unexpected error processing request: {} {}", request.method, request.path, e)
-                val errorBody = serializer.serialize(
-                    com.marcosbarbero.scim2.core.domain.model.error.ScimError(
-                        status = "500",
-                        detail = "Internal server error"
-                    )
-                )
-                ScimHttpResponse.error(500, errorBody)
+                val fallback = ScimException(status = 500, detail = "Internal server error")
+                buildErrorResponse(fallback, processedRequest)
             }
 
             val duration = Duration.between(start, Instant.now())
@@ -411,5 +405,21 @@ class ScimEndpointDispatcher(
         if (!check(evaluator)) {
             throw ScimException(status = 403, detail = "Forbidden")
         }
+    }
+
+    private fun buildErrorResponse(exception: ScimException, request: ScimHttpRequest): ScimHttpResponse {
+        val acceptsProblemJson = request.headers.entries
+            .firstOrNull { it.key.equals("Accept", ignoreCase = true) }
+            ?.value
+            ?.any { it.contains("application/problem+json") } == true
+
+        val body = if (acceptsProblemJson) {
+            serializer.serialize(exception.toScimProblemDetail())
+        } else {
+            serializer.serialize(exception.toScimError())
+        }
+
+        val contentType = if (acceptsProblemJson) "application/problem+json" else "application/scim+json"
+        return ScimHttpResponse.error(exception.status, body, mapOf("Content-Type" to contentType))
     }
 }

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/http/ScimHttpResponse.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/http/ScimHttpResponse.kt
@@ -37,6 +37,9 @@ data class ScimHttpResponse(
         fun error(status: Int, body: ByteArray): ScimHttpResponse =
             ScimHttpResponse(status = status, headers = SCIM_CONTENT_TYPE, body = body)
 
+        fun error(status: Int, body: ByteArray, headers: Map<String, String>): ScimHttpResponse =
+            ScimHttpResponse(status = status, headers = headers, body = body)
+
         private val SCIM_CONTENT_TYPE = mapOf("Content-Type" to "application/scim+json")
     }
 }

--- a/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
+++ b/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
@@ -8,6 +8,7 @@ import com.marcosbarbero.scim2.core.domain.model.error.ResourceConflictException
 import com.marcosbarbero.scim2.core.domain.model.error.ResourceNotFoundException
 import com.marcosbarbero.scim2.core.domain.model.error.ScimError
 import com.marcosbarbero.scim2.core.domain.model.error.ScimException
+import com.marcosbarbero.scim2.core.domain.model.error.ScimProblemDetail
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchOp
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchOperation
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
@@ -862,6 +863,99 @@ class ScimEndpointDispatcherTest {
         val response = dispatcher.dispatch(request)
 
         response.status shouldBe 200
+    }
+
+    // --- ProblemDetail content negotiation tests ---
+
+    @Test
+    fun `error with Accept problem+json returns ProblemDetail format`() {
+        val request = ScimHttpRequest(
+            method = HttpMethod.GET,
+            path = "${config.basePath}/Users/nonexistent-id",
+            headers = mapOf("Accept" to listOf("application/problem+json"))
+        )
+
+        val response = dispatcher.dispatch(request)
+
+        response.status shouldBe 404
+        response.headers["Content-Type"] shouldBe "application/problem+json"
+        val problemDetail = objectMapper.readValue(response.body, ScimProblemDetail::class.java)
+        problemDetail.status shouldBe 404
+        problemDetail.type shouldBe "about:blank"
+        problemDetail.title shouldBe "Not Found"
+        problemDetail.detail shouldNotBe null
+    }
+
+    @Test
+    fun `error with Accept scim+json returns ScimError format`() {
+        val request = ScimHttpRequest(
+            method = HttpMethod.GET,
+            path = "${config.basePath}/Users/nonexistent-id",
+            headers = mapOf("Accept" to listOf("application/scim+json"))
+        )
+
+        val response = dispatcher.dispatch(request)
+
+        response.status shouldBe 404
+        response.headers["Content-Type"] shouldBe "application/scim+json"
+        val error = objectMapper.readValue(response.body, ScimError::class.java)
+        error.status shouldBe "404"
+    }
+
+    @Test
+    fun `error without Accept header returns ScimError format by default`() {
+        val request = ScimHttpRequest(
+            method = HttpMethod.GET,
+            path = "${config.basePath}/Users/nonexistent-id"
+        )
+
+        val response = dispatcher.dispatch(request)
+
+        response.status shouldBe 404
+        response.headers["Content-Type"] shouldBe "application/scim+json"
+        val error = objectMapper.readValue(response.body, ScimError::class.java)
+        error.status shouldBe "404"
+    }
+
+    @Test
+    fun `error with Accept problem+json includes scimType when present`() {
+        val conflictHandler = object : ResourceHandler<User> {
+            override val resourceType: Class<User> = User::class.java
+            override val endpoint: String = "/Users"
+            override fun get(id: ResourceId, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
+            override fun create(resource: User, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
+            override fun replace(id: ResourceId, resource: User, version: ETag?, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
+            override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
+            override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) = throw ResourceConflictException("duplicate")
+            override fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<User> = throw ResourceConflictException("duplicate")
+        }
+
+        val conflictDispatcher = ScimEndpointDispatcher(
+            handlers = listOf(conflictHandler),
+            bulkHandler = null,
+            meHandler = null,
+            discoveryService = discoveryService,
+            config = config,
+            serializer = serializer
+        )
+
+        val body = objectMapper.writeValueAsBytes(
+            mapOf("schemas" to listOf(ScimUrns.USER), "userName" to "test")
+        )
+        val request = ScimHttpRequest(
+            method = HttpMethod.POST,
+            path = "${config.basePath}/Users",
+            headers = mapOf("Accept" to listOf("application/problem+json")),
+            body = body
+        )
+
+        val response = conflictDispatcher.dispatch(request)
+
+        response.status shouldBe 409
+        response.headers["Content-Type"] shouldBe "application/problem+json"
+        val problemDetail = objectMapper.readValue(response.body, ScimProblemDetail::class.java)
+        problemDetail.scimType shouldBe "uniqueness"
+        problemDetail.type shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:uniqueness"
     }
 
     private fun createTestUser(): User {

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/web/ScimExceptionHandler.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/web/ScimExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.marcosbarbero.scim2.spring.web
 
 import com.marcosbarbero.scim2.core.domain.model.error.ScimException
 import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
@@ -11,11 +12,22 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class ScimExceptionHandler(private val serializer: ScimSerializer) {
 
     @ExceptionHandler(ScimException::class)
-    fun handleScimException(ex: ScimException): ResponseEntity<ByteArray> {
-        val error = ex.toScimError()
-        val body = serializer.serialize(error)
-        return ResponseEntity.status(ex.status)
-            .contentType(MediaType("application", "scim+json"))
-            .body(body)
+    fun handleScimException(ex: ScimException, request: HttpServletRequest): ResponseEntity<ByteArray> {
+        val acceptsProblemJson = request.getHeader("Accept")
+            ?.contains("application/problem+json") == true
+
+        return if (acceptsProblemJson) {
+            val problemDetail = ex.toScimProblemDetail()
+            val body = serializer.serialize(problemDetail)
+            ResponseEntity.status(ex.status)
+                .contentType(MediaType("application", "problem+json"))
+                .body(body)
+        } else {
+            val error = ex.toScimError()
+            val body = serializer.serialize(error)
+            ResponseEntity.status(ex.status)
+                .contentType(MediaType("application", "scim+json"))
+                .body(body)
+        }
     }
 }

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/web/ScimExceptionHandlerTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/web/ScimExceptionHandlerTest.kt
@@ -1,0 +1,80 @@
+package com.marcosbarbero.scim2.spring.web
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.marcosbarbero.scim2.core.domain.model.error.InvalidFilterException
+import com.marcosbarbero.scim2.core.domain.model.error.ResourceNotFoundException
+import com.marcosbarbero.scim2.core.domain.model.error.ScimError
+import com.marcosbarbero.scim2.core.domain.model.error.ScimProblemDetail
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import io.github.serpro69.kfaker.Faker
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+class ScimExceptionHandlerTest {
+
+    private val faker = Faker()
+    private val objectMapper = jacksonObjectMapper()
+
+    private val serializer = object : ScimSerializer {
+        override fun <T : Any> serialize(value: T): ByteArray = objectMapper.writeValueAsBytes(value)
+        override fun <T : Any> deserialize(bytes: ByteArray, type: KClass<T>): T = objectMapper.readValue(bytes, type.java)
+        override fun serializeToString(value: Any): String = objectMapper.writeValueAsString(value)
+        override fun <T : Any> deserializeFromString(json: String, type: KClass<T>): T = objectMapper.readValue(json, type.java)
+    }
+
+    private val handler = ScimExceptionHandler(serializer)
+
+    @Test
+    fun `returns ScimError for application scim+json Accept`() {
+        val detail = faker.name.name()
+        val ex = ResourceNotFoundException(detail)
+        val request = mockk<HttpServletRequest>()
+        every { request.getHeader("Accept") } returns "application/scim+json"
+
+        val response = handler.handleScimException(ex, request)
+
+        response.statusCode.value() shouldBe 404
+        response.headers.contentType.toString() shouldBe "application/scim+json"
+        val error = objectMapper.readValue(response.body, ScimError::class.java)
+        error.status shouldBe "404"
+        error.detail shouldBe detail
+    }
+
+    @Test
+    fun `returns ProblemDetail for application problem+json Accept`() {
+        val detail = faker.name.name()
+        val ex = InvalidFilterException(detail)
+        val request = mockk<HttpServletRequest>()
+        every { request.getHeader("Accept") } returns "application/problem+json"
+
+        val response = handler.handleScimException(ex, request)
+
+        response.statusCode.value() shouldBe 400
+        response.headers.contentType.toString() shouldBe "application/problem+json"
+        val problemDetail = objectMapper.readValue(response.body, ScimProblemDetail::class.java)
+        problemDetail.status shouldBe 400
+        problemDetail.detail shouldBe detail
+        problemDetail.scimType shouldBe "invalidFilter"
+        problemDetail.type shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:invalidFilter"
+    }
+
+    @Test
+    fun `returns ScimError by default when no Accept header`() {
+        val detail = faker.name.name()
+        val ex = ResourceNotFoundException(detail)
+        val request = mockk<HttpServletRequest>()
+        every { request.getHeader("Accept") } returns null
+
+        val response = handler.handleScimException(ex, request)
+
+        response.statusCode.value() shouldBe 404
+        response.headers.contentType.toString() shouldBe "application/scim+json"
+        val error = objectMapper.readValue(response.body, ScimError::class.java)
+        error.status shouldBe "404"
+        error.detail shouldBe detail
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ScimProblemDetail` (RFC 9457) data class in core module with `fromScimException` and `fromScimError` factory methods
- Content negotiation in both `ScimEndpointDispatcher` (server module) and `ScimExceptionHandler` (Spring module): `Accept: application/problem+json` returns ProblemDetail format, otherwise standard SCIM error format
- ADR-0019: Documents the catch-all controller design decision
- ADR-0021: Documents the ProblemDetail content negotiation approach

## Test plan
- [x] `ScimProblemDetailTest`: field mapping, JSON serialization, round-trip, httpStatusTitle coverage
- [x] `ScimEndpointDispatcherTest`: ProblemDetail vs ScimError based on Accept header
- [x] `ScimExceptionHandlerTest`: Spring handler returns correct format based on Accept header
- [x] All existing tests continue to pass (no regressions)
- [x] `mvn clean verify` passes for core, server, and spring-boot-autoconfigure modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)