### PR TITLE
fix: Spring Boot configuration metadata for IDE autocompletion

### DIFF
--- a/scim2-sdk-spring-boot-autoconfigure/pom.xml
+++ b/scim2-sdk-spring-boot-autoconfigure/pom.xml
@@ -47,6 +47,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <optional>true</optional>
@@ -99,4 +104,11 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <!--
+        Note: spring-boot-configuration-processor (kapt) doesn't generate metadata for Kotlin
+        data classes with constructor binding. We use additional-spring-configuration-metadata.json
+        instead (src/main/resources/META-INF/), which is the recommended approach for Kotlin.
+        See: https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html
+    -->
 </project>

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,87 @@
+{
+  "properties": [
+    {
+      "name": "scim.base-path",
+      "type": "java.lang.String",
+      "description": "Base path for all SCIM 2.0 endpoints.",
+      "defaultValue": "/scim/v2"
+    },
+    {
+      "name": "scim.bulk.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether SCIM bulk operations are enabled.",
+      "defaultValue": true
+    },
+    {
+      "name": "scim.bulk.max-operations",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of operations in a single bulk request.",
+      "defaultValue": 1000
+    },
+    {
+      "name": "scim.bulk.max-payload-size",
+      "type": "java.lang.Long",
+      "description": "Maximum payload size in bytes for bulk requests.",
+      "defaultValue": 1048576
+    },
+    {
+      "name": "scim.filter.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether SCIM filtering is enabled.",
+      "defaultValue": true
+    },
+    {
+      "name": "scim.filter.max-results",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of results returned by a filtered query.",
+      "defaultValue": 200
+    },
+    {
+      "name": "scim.pagination.default-page-size",
+      "type": "java.lang.Integer",
+      "description": "Default page size when count is not specified.",
+      "defaultValue": 100
+    },
+    {
+      "name": "scim.pagination.max-page-size",
+      "type": "java.lang.Integer",
+      "description": "Maximum allowed page size.",
+      "defaultValue": 1000
+    },
+    {
+      "name": "scim.etag.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether ETag support is enabled for optimistic concurrency.",
+      "defaultValue": true
+    },
+    {
+      "name": "scim.patch.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether SCIM PATCH operations are enabled.",
+      "defaultValue": true
+    },
+    {
+      "name": "scim.sort.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether SCIM sorting is enabled.",
+      "defaultValue": false
+    },
+    {
+      "name": "scim.client.base-url",
+      "type": "java.lang.String",
+      "description": "Base URL of the remote SCIM service provider."
+    },
+    {
+      "name": "scim.client.connect-timeout",
+      "type": "java.time.Duration",
+      "description": "Connection timeout for the SCIM client.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "scim.client.read-timeout",
+      "type": "java.time.Duration",
+      "description": "Read timeout for the SCIM client.",
+      "defaultValue": "30s"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `additional-spring-configuration-metadata.json` with descriptions for all `scim.*` properties
- Adds `spring-boot-autoconfigure-processor` dependency for faster startup condition filtering
- Enables IDE autocompletion (IntelliJ, VS Code) for SCIM configuration properties

Note: Kotlin data classes with constructor binding don't work with the annotation processor's code generation, so we use the manual metadata file approach as recommended by Spring Boot docs.