### PR TITLE
feat: OOTB IdP adapters and outbox pattern documentation

### DIFF
--- a/docs/adr/0022-ootb-idp-adapters.md
+++ b/docs/adr/0022-ootb-idp-adapters.md
@@ -1,0 +1,28 @@
+# ADR-0022: OOTB IdP Adapters via Spring Security JWT
+
+## Status
+Accepted
+
+## Context
+The SDK's `IdentityResolver` interface requires every user to implement JWT claim extraction logic, even for well-known identity providers like Keycloak, Okta, Azure AD, PingFederate, and Auth0. Each IdP uses different JWT claim structures for roles, principals, and user attributes. This creates repetitive boilerplate for common deployments.
+
+## Decision
+We provide out-of-the-box `IdentityResolver` implementations for five major IdPs in the Spring Boot autoconfigure module:
+
+- **`JwtIdentityResolver`** -- Base class that extracts identity from Spring Security's `JwtAuthenticationToken` using configurable claim names (`sub`, `roles`, `email`).
+- **`KeycloakIdentityResolver`** -- Extracts realm roles from `realm_access.roles` and optional client roles from `resource_access.{clientId}.roles`.
+- **`OktaIdentityResolver`** -- Extracts roles from `groups` and `scp` (scopes) claims.
+- **`AzureAdIdentityResolver`** -- Uses `oid` as principal, extracts `roles` and `wids` (directory role IDs), plus `tid` (tenant ID).
+- **`PingFederateIdentityResolver`** -- Extracts roles from `memberOf` and `groups` claims.
+- **`Auth0IdentityResolver`** -- Extracts roles from `{namespace}/roles` and `permissions` claims.
+
+Selection is driven by the `scim.idp.provider` property. Each bean uses `@ConditionalOnMissingBean(IdentityResolver::class)` so a user-provided implementation always takes precedence. The entire auto-configuration activates only when `org.springframework.security.oauth2.jwt.Jwt` is on the classpath (`@ConditionalOnClass`).
+
+Spring Security OAuth2 Resource Server and JOSE dependencies are declared as `<optional>true</optional>` in the autoconfigure module, so they are not transitively pulled in.
+
+## Consequences
+- Zero-config identity resolution for the five most common IdPs.
+- The `JwtIdentityResolver` base class is `open`, so users can extend it for IdPs not covered OOTB.
+- Core and server modules remain free of Spring Security or IdP dependencies.
+- Adding a new IdP adapter is an additive, non-breaking change.
+- The `@ConditionalOnProperty` + `@ConditionalOnMissingBean` pattern ensures deterministic bean selection and clean back-off.

--- a/docs/outbox-pattern.md
+++ b/docs/outbox-pattern.md
@@ -1,0 +1,111 @@
+# Outbox Pattern for Reliable Event Publishing
+
+## Overview
+
+SCIM provisioning at scale (e.g., Azure AD syncing 100K+ users) can overwhelm downstream systems. The outbox pattern ensures reliable event publishing by storing events in the same database transaction as the resource change.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant SCIM Server
+    participant DB
+    participant Outbox Poller
+    participant Message Broker
+
+    Client->>SCIM Server: POST /Users
+    SCIM Server->>DB: BEGIN TX
+    SCIM Server->>DB: INSERT user
+    SCIM Server->>DB: INSERT outbox event
+    SCIM Server->>DB: COMMIT TX
+    SCIM Server-->>Client: 201 Created
+
+    loop Periodic poll
+        Outbox Poller->>DB: SELECT unprocessed events
+        Outbox Poller->>Message Broker: Publish events
+        Outbox Poller->>DB: Mark events processed
+    end
+```
+
+## Using the ScimOutboxPort
+
+The `ScimOutboxPort` interface in the server module defines the outbox contract:
+
+```kotlin
+interface ScimOutboxPort {
+    fun store(event: ScimEvent)
+}
+```
+
+### Option 1: namastack-outbox (Recommended)
+
+[namastack-outbox](https://github.com/namastack/namastack-outbox) integrates with Spring Modulith for transactional event publishing.
+
+Add the dependency:
+```xml
+<dependency>
+    <groupId>com.namastack</groupId>
+    <artifactId>namastack-outbox-spring-boot-starter</artifactId>
+    <version>${namastack-outbox.version}</version>
+</dependency>
+```
+
+Configure:
+```yaml
+scim:
+  outbox:
+    enabled: true
+```
+
+The SDK auto-configures a `NamastackOutboxAdapter` that implements `ScimOutboxPort` and delegates to namastack-outbox's `OutboxPublisher`.
+
+### Option 2: Custom Implementation
+
+Implement `ScimOutboxPort` and register as a Spring bean:
+
+```kotlin
+@Component
+class MyOutboxPort(private val jdbcTemplate: JdbcTemplate) : ScimOutboxPort {
+    override fun store(event: ScimEvent) {
+        jdbcTemplate.update(
+            "INSERT INTO my_outbox (event_id, event_type, payload, created_at) VALUES (?, ?, ?, ?)",
+            event.eventId, event::class.simpleName, objectMapper.writeValueAsString(event), event.timestamp
+        )
+    }
+}
+```
+
+### Option 3: Spring Application Events (No Outbox)
+
+By default, the SDK publishes `ScimEvent` instances via `ScimEventPublisher`. In Spring, these become `ApplicationEvent` instances that you can listen to:
+
+```kotlin
+@Component
+class ScimEventListener {
+    @EventListener
+    fun onResourceCreated(event: ResourceCreatedEvent) {
+        // Handle event (non-transactional, fire-and-forget)
+    }
+}
+```
+
+## Database Schema for Outbox
+
+If using a custom outbox implementation, here is a reference schema:
+
+```sql
+CREATE TABLE scim_outbox (
+    event_id        VARCHAR(255) NOT NULL PRIMARY KEY,
+    event_type      VARCHAR(100) NOT NULL,
+    resource_type   VARCHAR(100) NOT NULL,
+    resource_id     VARCHAR(255) NOT NULL,
+    correlation_id  VARCHAR(255),
+    payload         TEXT NOT NULL,
+    processed       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    processed_at    TIMESTAMP
+);
+
+CREATE INDEX idx_scim_outbox_unprocessed ON scim_outbox (processed, created_at) WHERE processed = FALSE;
+```

--- a/scim2-sdk-spring-boot-autoconfigure/pom.xml
+++ b/scim2-sdk-spring-boot-autoconfigure/pom.xml
@@ -72,6 +72,16 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
             <optional>true</optional>

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimIdentityAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimIdentityAutoConfiguration.kt
@@ -1,0 +1,58 @@
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.server.port.IdentityResolver
+import com.marcosbarbero.scim2.spring.security.Auth0IdentityResolver
+import com.marcosbarbero.scim2.spring.security.AzureAdIdentityResolver
+import com.marcosbarbero.scim2.spring.security.JwtIdentityResolver
+import com.marcosbarbero.scim2.spring.security.KeycloakIdentityResolver
+import com.marcosbarbero.scim2.spring.security.OktaIdentityResolver
+import com.marcosbarbero.scim2.spring.security.PingFederateIdentityResolver
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+/**
+ * Auto-configuration that registers an [IdentityResolver] based on the configured IdP provider.
+ * Activates only when Spring Security OAuth2 JWT classes are on the classpath.
+ * Each provider bean backs off via [ConditionalOnMissingBean] so users can always provide
+ * their own [IdentityResolver].
+ */
+@AutoConfiguration
+@ConditionalOnClass(name = ["org.springframework.security.oauth2.jwt.Jwt"])
+@EnableConfigurationProperties(ScimProperties::class)
+class ScimIdentityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(IdentityResolver::class)
+    @ConditionalOnProperty(prefix = "scim.idp", name = ["provider"], havingValue = "keycloak")
+    fun keycloakIdentityResolver(properties: ScimProperties): IdentityResolver =
+        KeycloakIdentityResolver(clientId = properties.idp.clientId)
+
+    @Bean
+    @ConditionalOnMissingBean(IdentityResolver::class)
+    @ConditionalOnProperty(prefix = "scim.idp", name = ["provider"], havingValue = "okta")
+    fun oktaIdentityResolver(): IdentityResolver = OktaIdentityResolver()
+
+    @Bean
+    @ConditionalOnMissingBean(IdentityResolver::class)
+    @ConditionalOnProperty(prefix = "scim.idp", name = ["provider"], havingValue = "azure-ad")
+    fun azureAdIdentityResolver(): IdentityResolver = AzureAdIdentityResolver()
+
+    @Bean
+    @ConditionalOnMissingBean(IdentityResolver::class)
+    @ConditionalOnProperty(prefix = "scim.idp", name = ["provider"], havingValue = "ping-federate")
+    fun pingFederateIdentityResolver(): IdentityResolver = PingFederateIdentityResolver()
+
+    @Bean
+    @ConditionalOnMissingBean(IdentityResolver::class)
+    @ConditionalOnProperty(prefix = "scim.idp", name = ["provider"], havingValue = "auth0")
+    fun auth0IdentityResolver(properties: ScimProperties): IdentityResolver =
+        Auth0IdentityResolver(namespace = properties.idp.namespace ?: "https://your-app.auth0.com")
+
+    @Bean
+    @ConditionalOnMissingBean(IdentityResolver::class)
+    fun defaultJwtIdentityResolver(): IdentityResolver = JwtIdentityResolver()
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProperties.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProperties.kt
@@ -13,8 +13,15 @@ data class ScimProperties(
     val patch: PatchProperties = PatchProperties(),
     val pagination: PaginationProperties = PaginationProperties(),
     val client: ClientProperties = ClientProperties(),
-    val persistence: PersistenceProperties = PersistenceProperties()
+    val persistence: PersistenceProperties = PersistenceProperties(),
+    val idp: IdpProperties = IdpProperties()
 ) {
+    data class IdpProperties(
+        val provider: String? = null,
+        val clientId: String? = null,
+        val namespace: String? = null
+    )
+
     data class BulkProperties(
         val enabled: Boolean = true,
         val maxOperations: Int = 1000,

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/Auth0IdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/Auth0IdentityResolver.kt
@@ -1,0 +1,26 @@
+package com.marcosbarbero.scim2.spring.security
+
+import org.springframework.security.oauth2.jwt.Jwt
+
+/**
+ * [JwtIdentityResolver] for Auth0.
+ * Extracts roles from custom namespace claims and permissions.
+ */
+class Auth0IdentityResolver(
+    private val namespace: String = "https://your-app.auth0.com"
+) : JwtIdentityResolver(subjectClaim = "sub", emailClaim = "email") {
+
+    override fun extractRoles(jwt: Jwt): Set<String> {
+        val roles = mutableSetOf<String>()
+        jwt.getClaimAsStringList("${namespace}/roles")?.let { roles.addAll(it) }
+        jwt.getClaimAsStringList("permissions")?.let { roles.addAll(it) }
+        return roles
+    }
+
+    override fun extractAttributes(jwt: Jwt): Map<String, String> {
+        val attrs = super.extractAttributes(jwt).toMutableMap()
+        jwt.getClaimAsString("nickname")?.let { attrs["nickname"] = it }
+        jwt.getClaimAsString("picture")?.let { attrs["picture"] = it }
+        return attrs
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/AzureAdIdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/AzureAdIdentityResolver.kt
@@ -1,0 +1,29 @@
+package com.marcosbarbero.scim2.spring.security
+
+import org.springframework.security.oauth2.jwt.Jwt
+
+/**
+ * [JwtIdentityResolver] for Azure AD (Microsoft Entra ID).
+ * Extracts roles from `roles` claim and app roles from `wids` claim.
+ * Uses `oid` (Object ID) as the principal identifier.
+ */
+class AzureAdIdentityResolver : JwtIdentityResolver(subjectClaim = "oid", emailClaim = "email") {
+
+    override fun extractPrincipal(jwt: Jwt): String =
+        jwt.getClaimAsString("oid") ?: jwt.getClaimAsString("sub") ?: "unknown"
+
+    override fun extractRoles(jwt: Jwt): Set<String> {
+        val roles = mutableSetOf<String>()
+        jwt.getClaimAsStringList("roles")?.let { roles.addAll(it) }
+        jwt.getClaimAsStringList("wids")?.let { roles.addAll(it) }
+        return roles
+    }
+
+    override fun extractAttributes(jwt: Jwt): Map<String, String> {
+        val attrs = super.extractAttributes(jwt).toMutableMap()
+        jwt.getClaimAsString("preferred_username")?.let { attrs["preferred_username"] = it }
+        jwt.getClaimAsString("tid")?.let { attrs["tenant_id"] = it }
+        jwt.getClaimAsString("appid")?.let { attrs["app_id"] = it }
+        return attrs
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolver.kt
@@ -1,0 +1,53 @@
+package com.marcosbarbero.scim2.spring.security
+
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import com.marcosbarbero.scim2.server.port.IdentityResolver
+import com.marcosbarbero.scim2.server.port.ScimRequestContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+/**
+ * Base [IdentityResolver] that extracts identity from a JWT in Spring Security's [SecurityContextHolder].
+ * Subclasses customize claim extraction for specific IdPs.
+ */
+open class JwtIdentityResolver(
+    private val subjectClaim: String = "sub",
+    private val rolesClaim: String = "roles",
+    private val emailClaim: String = "email"
+) : IdentityResolver {
+
+    override fun resolve(request: ScimHttpRequest): ScimRequestContext {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val jwt = when (authentication) {
+            is JwtAuthenticationToken -> authentication.token
+            else -> null
+        }
+
+        return if (jwt != null) {
+            ScimRequestContext(
+                principalId = extractPrincipal(jwt),
+                roles = extractRoles(jwt),
+                attributes = extractAttributes(jwt)
+            )
+        } else {
+            ScimRequestContext()
+        }
+    }
+
+    protected open fun extractPrincipal(jwt: Jwt): String =
+        jwt.getClaimAsString(subjectClaim) ?: jwt.subject ?: "unknown"
+
+    protected open fun extractRoles(jwt: Jwt): Set<String> {
+        val roles = jwt.getClaimAsStringList(rolesClaim)
+        return roles?.toSet() ?: emptySet()
+    }
+
+    protected open fun extractAttributes(jwt: Jwt): Map<String, String> {
+        val attrs = mutableMapOf<String, String>()
+        jwt.getClaimAsString(emailClaim)?.let { attrs["email"] = it }
+        jwt.getClaimAsString("name")?.let { attrs["name"] = it }
+        jwt.issuer?.let { attrs["issuer"] = it.toString() }
+        return attrs
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/KeycloakIdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/KeycloakIdentityResolver.kt
@@ -1,0 +1,35 @@
+package com.marcosbarbero.scim2.spring.security
+
+import org.springframework.security.oauth2.jwt.Jwt
+
+/**
+ * [JwtIdentityResolver] for Keycloak.
+ * Extracts roles from `realm_access.roles` and `resource_access.{client}.roles` claims.
+ */
+class KeycloakIdentityResolver(
+    private val clientId: String? = null
+) : JwtIdentityResolver(subjectClaim = "sub", rolesClaim = "realm_access", emailClaim = "email") {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun extractRoles(jwt: Jwt): Set<String> {
+        val roles = mutableSetOf<String>()
+        // Realm roles
+        val realmAccess = jwt.getClaim<Map<String, Any>>("realm_access")
+        (realmAccess?.get("roles") as? List<String>)?.let { roles.addAll(it) }
+        // Client roles
+        if (clientId != null) {
+            val resourceAccess = jwt.getClaim<Map<String, Any>>("resource_access")
+            val clientAccess = resourceAccess?.get(clientId) as? Map<String, Any>
+            (clientAccess?.get("roles") as? List<String>)?.let { roles.addAll(it) }
+        }
+        return roles
+    }
+
+    override fun extractAttributes(jwt: Jwt): Map<String, String> {
+        val attrs = super.extractAttributes(jwt).toMutableMap()
+        jwt.getClaimAsString("preferred_username")?.let { attrs["preferred_username"] = it }
+        jwt.getClaimAsString("given_name")?.let { attrs["given_name"] = it }
+        jwt.getClaimAsString("family_name")?.let { attrs["family_name"] = it }
+        return attrs
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/OktaIdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/OktaIdentityResolver.kt
@@ -1,0 +1,17 @@
+package com.marcosbarbero.scim2.spring.security
+
+import org.springframework.security.oauth2.jwt.Jwt
+
+/**
+ * [JwtIdentityResolver] for Okta.
+ * Extracts roles from the `groups` or `scp` (scopes) claims.
+ */
+class OktaIdentityResolver : JwtIdentityResolver(subjectClaim = "sub", emailClaim = "email") {
+
+    override fun extractRoles(jwt: Jwt): Set<String> {
+        val roles = mutableSetOf<String>()
+        jwt.getClaimAsStringList("groups")?.let { roles.addAll(it) }
+        jwt.getClaimAsStringList("scp")?.let { roles.addAll(it) }
+        return roles
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/PingFederateIdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/PingFederateIdentityResolver.kt
@@ -1,0 +1,17 @@
+package com.marcosbarbero.scim2.spring.security
+
+import org.springframework.security.oauth2.jwt.Jwt
+
+/**
+ * [JwtIdentityResolver] for PingFederate.
+ * Extracts roles from `memberOf` or `groups` claims.
+ */
+class PingFederateIdentityResolver : JwtIdentityResolver(subjectClaim = "sub", emailClaim = "email") {
+
+    override fun extractRoles(jwt: Jwt): Set<String> {
+        val roles = mutableSetOf<String>()
+        jwt.getClaimAsStringList("memberOf")?.let { roles.addAll(it) }
+        jwt.getClaimAsStringList("groups")?.let { roles.addAll(it) }
+        return roles
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -105,6 +105,22 @@
       "type": "java.lang.Boolean",
       "description": "Whether to automatically run Flyway migrations for the SCIM schema. When enabled, creates the scim_resources table on startup.",
       "defaultValue": false
+    },
+    {
+      "name": "scim.idp.provider",
+      "type": "java.lang.String",
+      "description": "Identity provider to auto-configure. Supported values: keycloak, okta, azure-ad, ping-federate, auth0."
+    },
+    {
+      "name": "scim.idp.client-id",
+      "type": "java.lang.String",
+      "description": "Client ID for Keycloak client-level role extraction from the resource_access claim."
+    },
+    {
+      "name": "scim.idp.namespace",
+      "type": "java.lang.String",
+      "description": "Custom namespace for Auth0 role claims (e.g., https://your-app.auth0.com).",
+      "defaultValue": "https://your-app.auth0.com"
     }
   ]
 }

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -5,3 +5,4 @@ com.marcosbarbero.scim2.spring.autoconfigure.ScimWebAutoConfiguration
 com.marcosbarbero.scim2.spring.autoconfigure.ScimObservabilityAutoConfiguration
 com.marcosbarbero.scim2.spring.autoconfigure.ScimPersistenceAutoConfiguration
 com.marcosbarbero.scim2.spring.autoconfigure.ScimFlywayAutoConfiguration
+com.marcosbarbero.scim2.spring.autoconfigure.ScimIdentityAutoConfiguration

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/Auth0IdentityResolverTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/Auth0IdentityResolverTest.kt
@@ -1,0 +1,124 @@
+package com.marcosbarbero.scim2.spring.security
+
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+class Auth0IdentityResolverTest {
+
+    private val resolver = Auth0IdentityResolver(namespace = "https://my-app.auth0.com")
+    private val request = ScimHttpRequest(method = HttpMethod.GET, path = "/scim/v2/Users")
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(SecurityContextHolder::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SecurityContextHolder::class)
+    }
+
+    private fun mockJwt(claims: Map<String, Any>): Jwt {
+        val jwt = mockk<Jwt>()
+        every { jwt.subject } returns (claims["sub"] as? String)
+        every { jwt.issuer } returns null
+        every { jwt.getClaimAsString(any()) } answers {
+            claims[firstArg<String>()] as? String
+        }
+        every { jwt.getClaimAsStringList(any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            claims[firstArg<String>()] as? List<String>
+        }
+        every { jwt.getClaim<Any>(any()) } answers {
+            claims[firstArg<String>()]
+        }
+        return jwt
+    }
+
+    private fun setAuthentication(jwt: Jwt) {
+        val auth = mockk<JwtAuthenticationToken>()
+        every { auth.token } returns jwt
+        val ctx = mockk<SecurityContext>()
+        every { ctx.authentication } returns auth
+        every { SecurityContextHolder.getContext() } returns ctx
+    }
+
+    @Test
+    fun `extracts roles from namespace roles claim`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "auth0|user-1",
+                "https://my-app.auth0.com/roles" to listOf("admin", "editor")
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("admin", "editor")
+    }
+
+    @Test
+    fun `extracts permissions claim`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "auth0|user-1",
+                "permissions" to listOf("read:users", "write:users")
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("read:users", "write:users")
+    }
+
+    @Test
+    fun `combines namespace roles and permissions`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "auth0|user-1",
+                "https://my-app.auth0.com/roles" to listOf("admin"),
+                "permissions" to listOf("read:users")
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("admin", "read:users")
+    }
+
+    @Test
+    fun `extracts nickname attribute`() {
+        val jwt = mockJwt(mapOf("sub" to "auth0|user-1", "nickname" to "johndoe"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes["nickname"] shouldBe "johndoe"
+    }
+
+    @Test
+    fun `extracts picture attribute`() {
+        val jwt = mockJwt(mapOf("sub" to "auth0|user-1", "picture" to "https://cdn.example.com/avatar.png"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes["picture"] shouldBe "https://cdn.example.com/avatar.png"
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/AzureAdIdentityResolverTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/AzureAdIdentityResolverTest.kt
@@ -1,0 +1,114 @@
+package com.marcosbarbero.scim2.spring.security
+
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+class AzureAdIdentityResolverTest {
+
+    private val resolver = AzureAdIdentityResolver()
+    private val request = ScimHttpRequest(method = HttpMethod.GET, path = "/scim/v2/Users")
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(SecurityContextHolder::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SecurityContextHolder::class)
+    }
+
+    private fun mockJwt(claims: Map<String, Any>): Jwt {
+        val jwt = mockk<Jwt>()
+        every { jwt.subject } returns (claims["sub"] as? String)
+        every { jwt.issuer } returns null
+        every { jwt.getClaimAsString(any()) } answers {
+            claims[firstArg<String>()] as? String
+        }
+        every { jwt.getClaimAsStringList(any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            claims[firstArg<String>()] as? List<String>
+        }
+        every { jwt.getClaim<Any>(any()) } answers {
+            claims[firstArg<String>()]
+        }
+        return jwt
+    }
+
+    private fun setAuthentication(jwt: Jwt) {
+        val auth = mockk<JwtAuthenticationToken>()
+        every { auth.token } returns jwt
+        val ctx = mockk<SecurityContext>()
+        every { ctx.authentication } returns auth
+        every { SecurityContextHolder.getContext() } returns ctx
+    }
+
+    @Test
+    fun `uses oid as principal`() {
+        val jwt = mockJwt(mapOf("oid" to "azure-oid-123", "sub" to "azure-sub"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.principalId shouldBe "azure-oid-123"
+    }
+
+    @Test
+    fun `falls back to sub when oid missing`() {
+        val jwt = mockJwt(mapOf("sub" to "azure-sub-456"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.principalId shouldBe "azure-sub-456"
+    }
+
+    @Test
+    fun `extracts roles and wids claims`() {
+        val jwt = mockJwt(
+            mapOf(
+                "oid" to "user-1",
+                "roles" to listOf("User.Read", "User.Write"),
+                "wids" to listOf("global-admin-wid")
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("User.Read", "User.Write", "global-admin-wid")
+    }
+
+    @Test
+    fun `extracts tenant_id from tid claim`() {
+        val jwt = mockJwt(mapOf("oid" to "user-1", "tid" to "tenant-abc"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes["tenant_id"] shouldBe "tenant-abc"
+    }
+
+    @Test
+    fun `extracts app_id from appid claim`() {
+        val jwt = mockJwt(mapOf("oid" to "user-1", "appid" to "app-xyz"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes["app_id"] shouldBe "app-xyz"
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolverTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolverTest.kt
@@ -1,0 +1,139 @@
+package com.marcosbarbero.scim2.spring.security
+
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import java.net.URL
+
+class JwtIdentityResolverTest {
+
+    private val resolver = JwtIdentityResolver()
+    private val request = ScimHttpRequest(method = HttpMethod.GET, path = "/scim/v2/Users")
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(SecurityContextHolder::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SecurityContextHolder::class)
+    }
+
+    private fun mockJwt(claims: Map<String, Any> = emptyMap()): Jwt {
+        val jwt = mockk<Jwt>()
+        every { jwt.subject } returns (claims["sub"] as? String)
+        every { jwt.issuer } returns (claims["iss"] as? URL)
+        every { jwt.getClaimAsString(any()) } answers {
+            val claim = firstArg<String>()
+            claims[claim] as? String
+        }
+        every { jwt.getClaimAsStringList(any()) } answers {
+            val claim = firstArg<String>()
+            @Suppress("UNCHECKED_CAST")
+            claims[claim] as? List<String>
+        }
+        every { jwt.getClaim<Any>(any()) } answers {
+            val claim = firstArg<String>()
+            claims[claim]
+        }
+        return jwt
+    }
+
+    private fun setAuthentication(jwt: Jwt) {
+        val authentication = mockk<JwtAuthenticationToken>()
+        every { authentication.token } returns jwt
+        val securityContext = mockk<SecurityContext>()
+        every { securityContext.authentication } returns authentication
+        every { SecurityContextHolder.getContext() } returns securityContext
+    }
+
+    private fun setNoAuthentication() {
+        val securityContext = mockk<SecurityContext>()
+        every { securityContext.authentication } returns null
+        every { SecurityContextHolder.getContext() } returns securityContext
+    }
+
+    @Test
+    fun `extracts principal from sub claim`() {
+        val jwt = mockJwt(mapOf("sub" to "user-123"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.principalId shouldBe "user-123"
+    }
+
+    @Test
+    fun `extracts roles from roles claim`() {
+        val jwt = mockJwt(mapOf("sub" to "user-1", "roles" to listOf("admin", "reader")))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles shouldBe setOf("admin", "reader")
+    }
+
+    @Test
+    fun `extracts email attribute`() {
+        val jwt = mockJwt(mapOf("sub" to "user-1", "email" to "user@example.com"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes shouldContainKey "email"
+        context.attributes["email"] shouldBe "user@example.com"
+    }
+
+    @Test
+    fun `handles missing claims gracefully`() {
+        val jwt = mockJwt(emptyMap())
+        every { jwt.subject } returns null
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.principalId shouldBe "unknown"
+        context.roles shouldBe emptySet()
+    }
+
+    @Test
+    fun `handles no authentication in SecurityContext`() {
+        setNoAuthentication()
+
+        val context = resolver.resolve(request)
+
+        context.principalId shouldBe null
+        context.roles shouldBe emptySet()
+        context.attributes shouldBe emptyMap()
+    }
+
+    @Test
+    fun `extracts name and issuer attributes`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "user-1",
+                "name" to "John Doe",
+                "iss" to URL("https://issuer.example.com")
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes["name"] shouldBe "John Doe"
+        context.attributes["issuer"] shouldBe "https://issuer.example.com"
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/KeycloakIdentityResolverTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/KeycloakIdentityResolverTest.kt
@@ -1,0 +1,123 @@
+package com.marcosbarbero.scim2.spring.security
+
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+class KeycloakIdentityResolverTest {
+
+    private val resolver = KeycloakIdentityResolver(clientId = "my-client")
+    private val request = ScimHttpRequest(method = HttpMethod.GET, path = "/scim/v2/Users")
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(SecurityContextHolder::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SecurityContextHolder::class)
+    }
+
+    private fun mockJwt(claims: Map<String, Any>): Jwt {
+        val jwt = mockk<Jwt>()
+        every { jwt.subject } returns (claims["sub"] as? String)
+        every { jwt.issuer } returns null
+        every { jwt.getClaimAsString(any()) } answers {
+            claims[firstArg<String>()] as? String
+        }
+        every { jwt.getClaimAsStringList(any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            claims[firstArg<String>()] as? List<String>
+        }
+        every { jwt.getClaim<Any>(any()) } answers {
+            claims[firstArg<String>()]
+        }
+        return jwt
+    }
+
+    private fun setAuthentication(jwt: Jwt) {
+        val auth = mockk<JwtAuthenticationToken>()
+        every { auth.token } returns jwt
+        val ctx = mockk<SecurityContext>()
+        every { ctx.authentication } returns auth
+        every { SecurityContextHolder.getContext() } returns ctx
+    }
+
+    @Test
+    fun `extracts realm_access roles`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "kc-user",
+                "realm_access" to mapOf("roles" to listOf("realm-admin", "user"))
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("realm-admin", "user")
+    }
+
+    @Test
+    fun `extracts resource_access client roles`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "kc-user",
+                "realm_access" to mapOf("roles" to listOf("user")),
+                "resource_access" to mapOf(
+                    "my-client" to mapOf("roles" to listOf("client-admin"))
+                )
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("user", "client-admin")
+    }
+
+    @Test
+    fun `extracts preferred_username attribute`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "kc-user",
+                "preferred_username" to "johndoe"
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes["preferred_username"] shouldBe "johndoe"
+    }
+
+    @Test
+    fun `extracts given_name and family_name attributes`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "kc-user",
+                "given_name" to "John",
+                "family_name" to "Doe"
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.attributes["given_name"] shouldBe "John"
+        context.attributes["family_name"] shouldBe "Doe"
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/OktaIdentityResolverTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/OktaIdentityResolverTest.kt
@@ -1,0 +1,104 @@
+package com.marcosbarbero.scim2.spring.security
+
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+class OktaIdentityResolverTest {
+
+    private val resolver = OktaIdentityResolver()
+    private val request = ScimHttpRequest(method = HttpMethod.GET, path = "/scim/v2/Users")
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(SecurityContextHolder::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(SecurityContextHolder::class)
+    }
+
+    private fun mockJwt(claims: Map<String, Any>): Jwt {
+        val jwt = mockk<Jwt>()
+        every { jwt.subject } returns (claims["sub"] as? String)
+        every { jwt.issuer } returns null
+        every { jwt.getClaimAsString(any()) } answers {
+            claims[firstArg<String>()] as? String
+        }
+        every { jwt.getClaimAsStringList(any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            claims[firstArg<String>()] as? List<String>
+        }
+        every { jwt.getClaim<Any>(any()) } answers {
+            claims[firstArg<String>()]
+        }
+        return jwt
+    }
+
+    private fun setAuthentication(jwt: Jwt) {
+        val auth = mockk<JwtAuthenticationToken>()
+        every { auth.token } returns jwt
+        val ctx = mockk<SecurityContext>()
+        every { ctx.authentication } returns auth
+        every { SecurityContextHolder.getContext() } returns ctx
+    }
+
+    @Test
+    fun `extracts groups claim as roles`() {
+        val jwt = mockJwt(mapOf("sub" to "okta-user", "groups" to listOf("Everyone", "Admins")))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("Everyone", "Admins")
+    }
+
+    @Test
+    fun `extracts scp claim as roles`() {
+        val jwt = mockJwt(mapOf("sub" to "okta-user", "scp" to listOf("openid", "profile")))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("openid", "profile")
+    }
+
+    @Test
+    fun `combines groups and scp claims`() {
+        val jwt = mockJwt(
+            mapOf(
+                "sub" to "okta-user",
+                "groups" to listOf("Admins"),
+                "scp" to listOf("openid")
+            )
+        )
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.roles.shouldContainExactlyInAnyOrder("Admins", "openid")
+    }
+
+    @Test
+    fun `extracts principal from sub`() {
+        val jwt = mockJwt(mapOf("sub" to "okta-user-123"))
+        setAuthentication(jwt)
+
+        val context = resolver.resolve(request)
+
+        context.principalId shouldBe "okta-user-123"
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/ScimIdentityAutoConfigurationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/ScimIdentityAutoConfigurationTest.kt
@@ -1,0 +1,94 @@
+package com.marcosbarbero.scim2.spring.security
+
+import com.marcosbarbero.scim2.server.port.IdentityResolver
+import com.marcosbarbero.scim2.spring.autoconfigure.ScimIdentityAutoConfiguration
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class ScimIdentityAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(ScimIdentityAutoConfiguration::class.java))
+
+    @Test
+    fun `provider=keycloak creates KeycloakIdentityResolver`() {
+        contextRunner
+            .withPropertyValues("scim.idp.provider=keycloak")
+            .run { context ->
+                val resolver = context.getBean(IdentityResolver::class.java)
+                resolver.shouldNotBeNull()
+                resolver.shouldBeInstanceOf<KeycloakIdentityResolver>()
+            }
+    }
+
+    @Test
+    fun `provider=okta creates OktaIdentityResolver`() {
+        contextRunner
+            .withPropertyValues("scim.idp.provider=okta")
+            .run { context ->
+                val resolver = context.getBean(IdentityResolver::class.java)
+                resolver.shouldNotBeNull()
+                resolver.shouldBeInstanceOf<OktaIdentityResolver>()
+            }
+    }
+
+    @Test
+    fun `provider=azure-ad creates AzureAdIdentityResolver`() {
+        contextRunner
+            .withPropertyValues("scim.idp.provider=azure-ad")
+            .run { context ->
+                val resolver = context.getBean(IdentityResolver::class.java)
+                resolver.shouldNotBeNull()
+                resolver.shouldBeInstanceOf<AzureAdIdentityResolver>()
+            }
+    }
+
+    @Test
+    fun `provider=ping-federate creates PingFederateIdentityResolver`() {
+        contextRunner
+            .withPropertyValues("scim.idp.provider=ping-federate")
+            .run { context ->
+                val resolver = context.getBean(IdentityResolver::class.java)
+                resolver.shouldNotBeNull()
+                resolver.shouldBeInstanceOf<PingFederateIdentityResolver>()
+            }
+    }
+
+    @Test
+    fun `provider=auth0 creates Auth0IdentityResolver`() {
+        contextRunner
+            .withPropertyValues("scim.idp.provider=auth0")
+            .run { context ->
+                val resolver = context.getBean(IdentityResolver::class.java)
+                resolver.shouldNotBeNull()
+                resolver.shouldBeInstanceOf<Auth0IdentityResolver>()
+            }
+    }
+
+    @Test
+    fun `no provider creates default JwtIdentityResolver`() {
+        contextRunner
+            .run { context ->
+                val resolver = context.getBean(IdentityResolver::class.java)
+                resolver.shouldNotBeNull()
+                resolver.shouldBeInstanceOf<JwtIdentityResolver>()
+            }
+    }
+
+    @Test
+    fun `custom IdentityResolver bean takes precedence`() {
+        val custom = mockk<IdentityResolver>()
+        contextRunner
+            .withPropertyValues("scim.idp.provider=keycloak")
+            .withBean("customResolver", IdentityResolver::class.java, { custom })
+            .run { context ->
+                val resolver = context.getBean(IdentityResolver::class.java)
+                resolver shouldBe custom
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `JwtIdentityResolver` base class and five IdP-specific implementations (Keycloak, Okta, Azure AD/Entra ID, PingFederate, Auth0) in the Spring Boot autoconfigure module
- Auto-configured via `scim.idp.provider` property with `@ConditionalOnMissingBean` back-off and `@ConditionalOnClass` activation (Spring Security OAuth2 JWT)
- Add `scim.idp.client-id` (Keycloak client roles) and `scim.idp.namespace` (Auth0 custom claims) configuration properties
- Add outbox pattern documentation with reference SQL schema and integration options (namastack-outbox, custom, Spring events)
- Add ADR-0022 documenting the IdP adapter approach

## Test plan
- [x] `JwtIdentityResolverTest` — sub/roles/email extraction, missing claims, no auth
- [x] `KeycloakIdentityResolverTest` — realm_access.roles, resource_access.{client}.roles
- [x] `OktaIdentityResolverTest` — groups and scp claims
- [x] `AzureAdIdentityResolverTest` — oid as principal, roles + wids, tid/appid
- [x] `Auth0IdentityResolverTest` — namespace/roles, permissions
- [x] `ScimIdentityAutoConfigurationTest` — all providers + default + custom back-off
- [x] Full `mvn clean verify` passes (65 tests in autoconfigure module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)