### PR TITLE
feat: Type-safe client API and RFC contract tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,37 +155,29 @@ val client = ScimClientBuilder()
     .authentication(BearerTokenAuthentication("your-token"))
     .build()
 
-// Create a user
-val user = User(userName = "john.doe", displayName = "John Doe")
+// Type-safe operations (recommended)
+val response = client.createUser(user)
+val user = client.getUser(id).value
+val results = client.searchUsers("userName sw \"john\"")
+client.patchUser(id, patch)
+client.deleteUser(id)
+
+// Group operations
+val group = client.createGroup(Group(displayName = "Admins"))
+val groups = client.searchGroups()
+
+// Generic typed operations (reads endpoint from @ScimResource annotation)
+val created = client.createResource(user) // detects /Users from annotation
+val fetched = client.getResource<User>(id)
+
+// Low-level operations (explicit endpoint and type)
 val response = client.create("/Users", user, User::class)
-
-// Search with SearchRequest
-val searchRequest = SearchRequest(
-    filter = "userName sw \"john\"",
-    sortBy = "userName",
-    count = 25
-)
 val results = client.search("/Users", searchRequest, User::class)
-
-// Patch with PatchRequest
-val patch = PatchRequest(
-    operations = listOf(
-        PatchOperation(op = PatchOp.REPLACE, path = "displayName", value = TextNode("John D. Doe")),
-        PatchOperation(op = PatchOp.REMOVE, path = "nickName")
-    )
-)
-client.patch("/Users", userId, patch, User::class)
 ```
 
 #### Java client usage
 
 ```java
-import kotlin.jvm.JvmClassMappingKt;
-import kotlin.reflect.KClass;
-
-// Helper to convert Java Class to Kotlin KClass (one-line utility)
-static <T> KClass<T> kclass(Class<T> c) { return JvmClassMappingKt.getKotlinClass(c); }
-
 ScimClient client = new ScimClientBuilder()
     .baseUrl("https://scim.example.com/scim/v2")
     .transport(new JavaHttpClientTransport())
@@ -193,27 +185,15 @@ ScimClient client = new ScimClientBuilder()
     .authentication(new BearerTokenAuthentication("your-token"))
     .build();
 
-// Create a user — all fields except userName are optional (null)
-User user = new User(
-    null, null, null,        // id, externalId, meta
-    "john.doe",              // userName (required)
-    null, "John Doe", null, null, null, null, null, null, null, null, null,
-    List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of()
-);
-ScimResponse<User> response = client.create("/Users", user, kclass(User.class));
+// Type-safe operations via ScimClients utility class
+ScimResponse<User> response = ScimClients.createUser(client, user);
+User user = ScimClients.getUser(client, id).getValue();
+ScimClients.deleteUser(client, id);
+ScimClients.searchUsers(client, new SearchRequest());
 
-// Search — schemas is non-null, use ScimUrns.SEARCH_REQUEST
-SearchRequest searchRequest = new SearchRequest(
-    List.of(ScimUrns.SEARCH_REQUEST),  // schemas
-    "userName sw \"john\"",            // filter
-    "userName",                        // sortBy
-    null,                              // sortOrder
-    1,                                 // startIndex
-    25,                                // count
-    null,                              // attributes
-    null                               // excludedAttributes
-);
-ScimResponse<ListResponse<User>> results = client.search("/Users", searchRequest, kclass(User.class));
+// Group operations
+ScimClients.createGroup(client, group);
+ScimClients.getGroup(client, id);
 ```
 
 ## Modules

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClientExtensions.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClientExtensions.kt
@@ -1,0 +1,74 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
+import com.marcosbarbero.scim2.core.domain.model.resource.Group
+import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
+import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+import kotlin.reflect.full.findAnnotation
+
+// ===== User Operations =====
+
+fun ScimClient.createUser(user: User): ScimResponse<User> =
+    create("/Users", user, User::class)
+
+fun ScimClient.getUser(id: String): ScimResponse<User> =
+    get("/Users", id, User::class)
+
+fun ScimClient.replaceUser(id: String, user: User): ScimResponse<User> =
+    replace("/Users", id, user, User::class)
+
+fun ScimClient.patchUser(id: String, patchRequest: PatchRequest): ScimResponse<User> =
+    patch("/Users", id, patchRequest, User::class)
+
+fun ScimClient.deleteUser(id: String): Unit =
+    delete("/Users", id)
+
+fun ScimClient.searchUsers(request: SearchRequest = SearchRequest()): ScimResponse<ListResponse<User>> =
+    search("/Users", request, User::class)
+
+fun ScimClient.searchUsers(filter: String): ScimResponse<ListResponse<User>> =
+    search("/Users", SearchRequest(filter = filter), User::class)
+
+// ===== Group Operations =====
+
+fun ScimClient.createGroup(group: Group): ScimResponse<Group> =
+    create("/Groups", group, Group::class)
+
+fun ScimClient.getGroup(id: String): ScimResponse<Group> =
+    get("/Groups", id, Group::class)
+
+fun ScimClient.replaceGroup(id: String, group: Group): ScimResponse<Group> =
+    replace("/Groups", id, group, Group::class)
+
+fun ScimClient.patchGroup(id: String, patchRequest: PatchRequest): ScimResponse<Group> =
+    patch("/Groups", id, patchRequest, Group::class)
+
+fun ScimClient.deleteGroup(id: String): Unit =
+    delete("/Groups", id)
+
+fun ScimClient.searchGroups(request: SearchRequest = SearchRequest()): ScimResponse<ListResponse<Group>> =
+    search("/Groups", request, Group::class)
+
+// ===== Generic typed operations (reads endpoint from @ScimResource annotation) =====
+
+inline fun <reified T : ScimResource> ScimClient.createResource(resource: T): ScimResponse<T> {
+    val endpoint = T::class.findAnnotation<com.marcosbarbero.scim2.core.schema.annotation.ScimResource>()?.endpoint
+        ?: throw IllegalArgumentException("${T::class.simpleName} is not annotated with @ScimResource")
+    return create(endpoint, resource, T::class)
+}
+
+inline fun <reified T : ScimResource> ScimClient.getResource(id: String): ScimResponse<T> {
+    val endpoint = T::class.findAnnotation<com.marcosbarbero.scim2.core.schema.annotation.ScimResource>()?.endpoint
+        ?: throw IllegalArgumentException("${T::class.simpleName} is not annotated with @ScimResource")
+    return get(endpoint, id, T::class)
+}
+
+inline fun <reified T : ScimResource> ScimClient.searchResources(
+    request: SearchRequest = SearchRequest()
+): ScimResponse<ListResponse<T>> {
+    val endpoint = T::class.findAnnotation<com.marcosbarbero.scim2.core.schema.annotation.ScimResource>()?.endpoint
+        ?: throw IllegalArgumentException("${T::class.simpleName} is not annotated with @ScimResource")
+    return search(endpoint, request, T::class)
+}

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClients.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/ScimClients.kt
@@ -1,0 +1,70 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
+import com.marcosbarbero.scim2.core.domain.model.resource.Group
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
+import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+
+/**
+ * Java-friendly static methods for type-safe SCIM operations.
+ * Kotlin users should prefer the extension functions on [ScimClient].
+ */
+object ScimClients {
+
+    // ===== User Operations =====
+
+    @JvmStatic
+    fun createUser(client: ScimClient, user: User): ScimResponse<User> =
+        client.createUser(user)
+
+    @JvmStatic
+    fun getUser(client: ScimClient, id: String): ScimResponse<User> =
+        client.getUser(id)
+
+    @JvmStatic
+    fun replaceUser(client: ScimClient, id: String, user: User): ScimResponse<User> =
+        client.replaceUser(id, user)
+
+    @JvmStatic
+    fun patchUser(client: ScimClient, id: String, patchRequest: PatchRequest): ScimResponse<User> =
+        client.patchUser(id, patchRequest)
+
+    @JvmStatic
+    fun deleteUser(client: ScimClient, id: String): Unit =
+        client.deleteUser(id)
+
+    @JvmStatic
+    fun searchUsers(client: ScimClient, request: SearchRequest): ScimResponse<ListResponse<User>> =
+        client.searchUsers(request)
+
+    @JvmStatic
+    fun searchUsers(client: ScimClient, filter: String): ScimResponse<ListResponse<User>> =
+        client.searchUsers(filter)
+
+    // ===== Group Operations =====
+
+    @JvmStatic
+    fun createGroup(client: ScimClient, group: Group): ScimResponse<Group> =
+        client.createGroup(group)
+
+    @JvmStatic
+    fun getGroup(client: ScimClient, id: String): ScimResponse<Group> =
+        client.getGroup(id)
+
+    @JvmStatic
+    fun replaceGroup(client: ScimClient, id: String, group: Group): ScimResponse<Group> =
+        client.replaceGroup(id, group)
+
+    @JvmStatic
+    fun patchGroup(client: ScimClient, id: String, patchRequest: PatchRequest): ScimResponse<Group> =
+        client.patchGroup(id, patchRequest)
+
+    @JvmStatic
+    fun deleteGroup(client: ScimClient, id: String): Unit =
+        client.deleteGroup(id)
+
+    @JvmStatic
+    fun searchGroups(client: ScimClient, request: SearchRequest): ScimResponse<ListResponse<Group>> =
+        client.searchGroups(request)
+}

--- a/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/ScimClientExtensionsTest.kt
+++ b/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/ScimClientExtensionsTest.kt
@@ -1,0 +1,239 @@
+package com.marcosbarbero.scim2.client.api
+
+import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
+import com.marcosbarbero.scim2.core.domain.model.resource.Group
+import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
+import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+class ScimClientExtensionsTest {
+
+    private lateinit var client: ScimClient
+
+    private val userResponse = ScimResponse(
+        value = User(id = "u1", userName = "john"),
+        statusCode = 200
+    )
+    private val groupResponse = ScimResponse(
+        value = Group(id = "g1", displayName = "admins"),
+        statusCode = 200
+    )
+
+    @BeforeEach
+    fun setUp() {
+        client = mockk(relaxed = true)
+    }
+
+    // ===== User Operations =====
+
+    @Test
+    fun `createUser calls create with Users endpoint and User class`() {
+        val user = User(userName = "john")
+        val expected = ScimResponse(value = User(id = "u1", userName = "john"), statusCode = 201)
+        every { client.create("/Users", user, User::class) } returns expected
+
+        val result = client.createUser(user)
+
+        result shouldBe expected
+        verify { client.create("/Users", user, User::class) }
+    }
+
+    @Test
+    fun `getUser calls get with Users endpoint and User class`() {
+        every { client.get("/Users", "u1", User::class) } returns userResponse
+
+        val result = client.getUser("u1")
+
+        result shouldBe userResponse
+        verify { client.get("/Users", "u1", User::class) }
+    }
+
+    @Test
+    fun `replaceUser calls replace with Users endpoint and User class`() {
+        val user = User(id = "u1", userName = "updated")
+        every { client.replace("/Users", "u1", user, User::class) } returns userResponse
+
+        client.replaceUser("u1", user)
+
+        verify { client.replace("/Users", "u1", user, User::class) }
+    }
+
+    @Test
+    fun `patchUser calls patch with Users endpoint and User class`() {
+        val patch = PatchRequest()
+        every { client.patch("/Users", "u1", patch, User::class) } returns userResponse
+
+        client.patchUser("u1", patch)
+
+        verify { client.patch("/Users", "u1", patch, User::class) }
+    }
+
+    @Test
+    fun `deleteUser calls delete with Users endpoint`() {
+        client.deleteUser("u1")
+
+        verify { client.delete("/Users", "u1") }
+    }
+
+    @Test
+    fun `searchUsers with default request calls search with Users endpoint`() {
+        val listResponse = ScimResponse(
+            value = ListResponse<User>(totalResults = 0),
+            statusCode = 200
+        )
+        every { client.search("/Users", any<SearchRequest>(), User::class) } returns listResponse
+
+        client.searchUsers()
+
+        verify { client.search("/Users", any<SearchRequest>(), User::class) }
+    }
+
+    @Test
+    fun `searchUsers with filter string builds SearchRequest`() {
+        val listResponse = ScimResponse(
+            value = ListResponse<User>(totalResults = 1, resources = listOf(User(userName = "john"))),
+            statusCode = 200
+        )
+        val requestSlot = slot<SearchRequest>()
+        every { client.search("/Users", capture(requestSlot), User::class) } returns listResponse
+
+        client.searchUsers("userName sw \"john\"")
+
+        requestSlot.captured.filter shouldBe "userName sw \"john\""
+    }
+
+    // ===== Group Operations =====
+
+    @Test
+    fun `createGroup calls create with Groups endpoint and Group class`() {
+        val group = Group(displayName = "admins")
+        val expected = ScimResponse(value = Group(id = "g1", displayName = "admins"), statusCode = 201)
+        every { client.create("/Groups", group, Group::class) } returns expected
+
+        val result = client.createGroup(group)
+
+        result shouldBe expected
+        verify { client.create("/Groups", group, Group::class) }
+    }
+
+    @Test
+    fun `getGroup calls get with Groups endpoint and Group class`() {
+        every { client.get("/Groups", "g1", Group::class) } returns groupResponse
+
+        val result = client.getGroup("g1")
+
+        result shouldBe groupResponse
+        verify { client.get("/Groups", "g1", Group::class) }
+    }
+
+    @Test
+    fun `replaceGroup calls replace with Groups endpoint and Group class`() {
+        val group = Group(id = "g1", displayName = "updated")
+        every { client.replace("/Groups", "g1", group, Group::class) } returns groupResponse
+
+        client.replaceGroup("g1", group)
+
+        verify { client.replace("/Groups", "g1", group, Group::class) }
+    }
+
+    @Test
+    fun `patchGroup calls patch with Groups endpoint and Group class`() {
+        val patch = PatchRequest()
+        every { client.patch("/Groups", "g1", patch, Group::class) } returns groupResponse
+
+        client.patchGroup("g1", patch)
+
+        verify { client.patch("/Groups", "g1", patch, Group::class) }
+    }
+
+    @Test
+    fun `deleteGroup calls delete with Groups endpoint`() {
+        client.deleteGroup("g1")
+
+        verify { client.delete("/Groups", "g1") }
+    }
+
+    @Test
+    fun `searchGroups calls search with Groups endpoint`() {
+        val listResponse = ScimResponse(
+            value = ListResponse<Group>(totalResults = 0),
+            statusCode = 200
+        )
+        every { client.search("/Groups", any<SearchRequest>(), Group::class) } returns listResponse
+
+        client.searchGroups()
+
+        verify { client.search("/Groups", any<SearchRequest>(), Group::class) }
+    }
+
+    // ===== Generic typed operations =====
+
+    @Test
+    fun `createResource reads ScimResource annotation for User`() {
+        val user = User(userName = "john")
+        val expected = ScimResponse(value = User(id = "u1", userName = "john"), statusCode = 201)
+        every { client.create("/Users", user, User::class) } returns expected
+
+        val result = client.createResource(user)
+
+        result shouldBe expected
+        verify { client.create("/Users", user, User::class) }
+    }
+
+    @Test
+    fun `createResource reads ScimResource annotation for Group`() {
+        val group = Group(displayName = "admins")
+        val expected = ScimResponse(value = Group(id = "g1", displayName = "admins"), statusCode = 201)
+        every { client.create("/Groups", group, Group::class) } returns expected
+
+        val result = client.createResource(group)
+
+        result shouldBe expected
+        verify { client.create("/Groups", group, Group::class) }
+    }
+
+    @Test
+    fun `createResource throws for unannotated class`() {
+        val unannotated = object : ScimResource(schemas = listOf("urn:test")) {}
+
+        val exception = shouldThrow<IllegalArgumentException> {
+            client.createResource(unannotated)
+        }
+
+        exception.message shouldContain "is not annotated with @ScimResource"
+    }
+
+    @Test
+    fun `getResource reads ScimResource annotation`() {
+        every { client.get("/Users", "u1", User::class) } returns userResponse
+
+        val result = client.getResource<User>("u1")
+
+        result shouldBe userResponse
+        verify { client.get("/Users", "u1", User::class) }
+    }
+
+    @Test
+    fun `searchResources reads ScimResource annotation`() {
+        val listResponse = ScimResponse(
+            value = ListResponse<User>(totalResults = 0),
+            statusCode = 200
+        )
+        every { client.search("/Users", any<SearchRequest>(), User::class) } returns listResponse
+
+        client.searchResources<User>()
+
+        verify { client.search("/Users", any<SearchRequest>(), User::class) }
+    }
+}

--- a/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/contract/ScimApiContractTest.kt
+++ b/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/contract/ScimApiContractTest.kt
@@ -1,0 +1,362 @@
+package com.marcosbarbero.scim2.test.contract
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.marcosbarbero.scim2.core.domain.ScimUrns
+import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
+import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import com.marcosbarbero.scim2.server.http.ScimHttpResponse
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Abstract contract test that validates HTTP-level RFC 7644 compliance.
+ * Tests verify response status codes, headers, and body format at the HTTP layer.
+ *
+ * Extend this class and implement [createDispatcher] to test any SCIM endpoint implementation.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc7644">RFC 7644: SCIM Protocol</a>
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc7643">RFC 7643: SCIM Core Schema</a>
+ */
+abstract class ScimApiContractTest {
+
+    abstract fun createDispatcher(): ScimEndpointDispatcher
+
+    abstract fun sampleUserJson(): ByteArray
+
+    private lateinit var dispatcher: ScimEndpointDispatcher
+    private val objectMapper = JacksonScimSerializer.defaultObjectMapper()
+
+    @BeforeEach
+    fun setUp() {
+        dispatcher = createDispatcher()
+    }
+
+    // === CREATE (POST) — RFC 7644 §3.1 ===
+
+    /**
+     * RFC 7644 §3.1: "If the service provider determines that the creation of the requested
+     * resource is feasible and the request is well formed, the service provider SHALL create
+     * the resource and respond with HTTP status code 201 (Created)."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.1">RFC 7644 §3.1</a>
+     */
+    @Test
+    fun `POST returns 201 Created (RFC 7644 §3-1)`() {
+        val response = post("/Users", sampleUserJson())
+        response.status shouldBe 201
+    }
+
+    /**
+     * RFC 7644 §3.1: "The response MUST include a Location header indicating the URI of the
+     * newly created resource."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.1">RFC 7644 §3.1</a>
+     */
+    @Test
+    fun `POST response includes Location header (RFC 7644 §3-1)`() {
+        val response = post("/Users", sampleUserJson())
+        response.headers["Location"].shouldNotBeNull()
+        response.headers["Location"]!! shouldContain "/Users/"
+    }
+
+    /**
+     * RFC 7643 §3: "The 'schemas' attribute is a REQUIRED attribute and is of type List of URIs."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7643#section-3">RFC 7643 §3</a>
+     */
+    @Test
+    fun `POST response body contains schemas array (RFC 7643 §3)`() {
+        val response = post("/Users", sampleUserJson())
+        val body = parseJson(response)
+        body.has("schemas") shouldBe true
+        body["schemas"].isArray shouldBe true
+        body["schemas"].size() shouldBeGreaterThan 0
+    }
+
+    /**
+     * RFC 7644 §3.1: "The response body SHOULD contain the created resource."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.1">RFC 7644 §3.1</a>
+     */
+    @Test
+    fun `POST response body contains id and meta (RFC 7644 §3-1)`() {
+        val response = post("/Users", sampleUserJson())
+        val body = parseJson(response)
+        body.has("id") shouldBe true
+        body["id"].asText().isNotBlank() shouldBe true
+        body.has("meta") shouldBe true
+        body["meta"].has("resourceType") shouldBe true
+        body["meta"].has("created") shouldBe true
+    }
+
+    // === READ (GET) — RFC 7644 §3.2 ===
+
+    /**
+     * RFC 7644 §3.2: "If the resource exists, the server responds with HTTP status code 200."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.2">RFC 7644 §3.2</a>
+     */
+    @Test
+    fun `GET by id returns 200 OK (RFC 7644 §3-2)`() {
+        val created = post("/Users", sampleUserJson())
+        val id = parseJson(created)["id"].asText()
+        val response = get("/Users/$id")
+        response.status shouldBe 200
+    }
+
+    /**
+     * RFC 7644 §3.2: "If the resource does not exist, the server responds with HTTP status code 404."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.2">RFC 7644 §3.2</a>
+     */
+    @Test
+    fun `GET non-existent returns 404 Not Found (RFC 7644 §3-2)`() {
+        val response = get("/Users/nonexistent-id")
+        response.status shouldBe 404
+    }
+
+    /**
+     * RFC 7644 §3.12: "404 error responses ... include a detail error message ..."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.12">RFC 7644 §3.12</a>
+     */
+    @Test
+    fun `GET 404 response is a valid ScimError (RFC 7644 §3-12)`() {
+        val response = get("/Users/nonexistent-id")
+        val body = parseJson(response)
+        body["schemas"][0].asText() shouldBe ScimUrns.ERROR
+        body["status"].asText() shouldBe "404"
+    }
+
+    // === ETAG — RFC 7644 §3.14 ===
+
+    /**
+     * RFC 7644 §3.14: "The service provider SHOULD return an ETag for the resource."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.14">RFC 7644 §3.14</a>
+     */
+    @Test
+    fun `GET response includes ETag header (RFC 7644 §3-14)`() {
+        val created = post("/Users", sampleUserJson())
+        val id = parseJson(created)["id"].asText()
+        val response = get("/Users/$id")
+        response.headers["ETag"].shouldNotBeNull()
+    }
+
+    /**
+     * RFC 7644 §3.14: "If the request includes an If-None-Match header and the ETag matches,
+     * the server SHOULD respond with 304 Not Modified."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.14">RFC 7644 §3.14</a>
+     */
+    @Test
+    fun `GET with matching If-None-Match returns 304 Not Modified (RFC 7644 §3-14)`() {
+        val created = post("/Users", sampleUserJson())
+        val id = parseJson(created)["id"].asText()
+        val getResponse = get("/Users/$id")
+        val etag = getResponse.headers["ETag"]!!
+        val conditionalResponse = get("/Users/$id", headers = mapOf("If-None-Match" to listOf(etag)))
+        conditionalResponse.status shouldBe 304
+    }
+
+    // === DELETE — RFC 7644 §3.6 ===
+
+    /**
+     * RFC 7644 §3.6: "the server SHALL respond with 204 (No Content)"
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.6">RFC 7644 §3.6</a>
+     */
+    @Test
+    fun `DELETE returns 204 No Content (RFC 7644 §3-6)`() {
+        val created = post("/Users", sampleUserJson())
+        val id = parseJson(created)["id"].asText()
+        val response = delete("/Users/$id")
+        response.status shouldBe 204
+    }
+
+    // === REPLACE (PUT) — RFC 7644 §3.3 ===
+
+    /**
+     * RFC 7644 §3.3: "If the resource exists, the service provider SHALL replace..."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.3">RFC 7644 §3.3</a>
+     */
+    @Test
+    fun `PUT returns 200 OK (RFC 7644 §3-3)`() {
+        val created = post("/Users", sampleUserJson())
+        val id = parseJson(created)["id"].asText()
+        val response = put("/Users/$id", sampleUserJson())
+        response.status shouldBe 200
+    }
+
+    // === PATCH — RFC 7644 §3.5.2 ===
+
+    /**
+     * RFC 7644 §3.5.2: "The server SHALL return ... 200 OK with the modified resource"
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2">RFC 7644 §3.5.2</a>
+     */
+    @Test
+    fun `PATCH returns 200 OK (RFC 7644 §3-5-2)`() {
+        val created = post("/Users", sampleUserJson())
+        val id = parseJson(created)["id"].asText()
+        val patchBody = objectMapper.writeValueAsBytes(
+            mapOf(
+                "schemas" to listOf(ScimUrns.PATCH_OP),
+                "Operations" to listOf(
+                    mapOf("op" to "replace", "path" to "displayName", "value" to "Updated")
+                )
+            )
+        )
+        val response = patch("/Users/$id", patchBody)
+        response.status shouldBe 200
+    }
+
+    // === SEARCH (GET with query) — RFC 7644 §3.4.2 ===
+
+    /**
+     * RFC 7644 §3.4.2: "The response body ... is a JSON structure containing the 'schemas',
+     * 'totalResults', 'Resources', 'startIndex', and 'itemsPerPage' attributes."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2">RFC 7644 §3.4.2</a>
+     */
+    @Test
+    fun `GET search returns ListResponse with required fields (RFC 7644 §3-4-2)`() {
+        post("/Users", sampleUserJson())
+        val response = get("/Users")
+        response.status shouldBe 200
+        val body = parseJson(response)
+        body.has("schemas") shouldBe true
+        body["schemas"][0].asText() shouldBe ScimUrns.LIST_RESPONSE
+        body.has("totalResults") shouldBe true
+        body.has("startIndex") shouldBe true
+        body.has("itemsPerPage") shouldBe true
+        body.has("Resources") shouldBe true
+    }
+
+    // === SEARCH (POST /.search) — RFC 7644 §3.4.3 ===
+
+    /**
+     * RFC 7644 §3.4.3: "Clients MAY execute queries ... using HTTP POST"
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.4.3">RFC 7644 §3.4.3</a>
+     */
+    @Test
+    fun `POST search returns ListResponse (RFC 7644 §3-4-3)`() {
+        post("/Users", sampleUserJson())
+        val searchBody = objectMapper.writeValueAsBytes(
+            mapOf(
+                "schemas" to listOf(ScimUrns.SEARCH_REQUEST),
+                "startIndex" to 1,
+                "count" to 10
+            )
+        )
+        val response = postSearch("/Users/.search", searchBody)
+        response.status shouldBe 200
+        val body = parseJson(response)
+        body["schemas"][0].asText() shouldBe ScimUrns.LIST_RESPONSE
+    }
+
+    // === DISCOVERY — RFC 7644 §4 ===
+
+    /**
+     * RFC 7644 §4: "Service provider configurations ... SHALL be retrievable."
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-4">RFC 7644 §4</a>
+     */
+    @Test
+    fun `GET ServiceProviderConfig returns 200 (RFC 7644 §4)`() {
+        val response = get("/ServiceProviderConfig")
+        response.status shouldBe 200
+    }
+
+    @Test
+    fun `GET Schemas returns 200 with schema list (RFC 7644 §4)`() {
+        val response = get("/Schemas")
+        response.status shouldBe 200
+    }
+
+    @Test
+    fun `GET ResourceTypes returns 200 with resource types (RFC 7644 §4)`() {
+        val response = get("/ResourceTypes")
+        response.status shouldBe 200
+    }
+
+    // === CONTENT-TYPE — RFC 7644 §3.1 ===
+
+    /**
+     * RFC 7644 §3.1: "Responses ... SHOULD specify a Content-Type of 'application/scim+json'"
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.1">RFC 7644 §3.1</a>
+     */
+    @Test
+    fun `error response Content-Type is application scim+json (RFC 7644 §3-1)`() {
+        val response = get("/Users/nonexistent")
+        response.headers["Content-Type"] shouldBe "application/scim+json"
+    }
+
+    /**
+     * RFC 7644 §3.1: Successful create responses should include Content-Type application/scim+json.
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc7644#section-3.1">RFC 7644 §3.1</a>
+     */
+    @Test
+    fun `POST response Content-Type is application scim+json (RFC 7644 §3-1)`() {
+        val response = post("/Users", sampleUserJson())
+        response.headers["Content-Type"] shouldBe "application/scim+json"
+    }
+
+    // === Helper methods ===
+
+    private fun post(path: String, body: ByteArray): ScimHttpResponse =
+        dispatcher.dispatch(
+            ScimHttpRequest(
+                method = HttpMethod.POST,
+                path = "${basePath()}$path",
+                body = body,
+                headers = mapOf("Content-Type" to listOf("application/scim+json"))
+            )
+        )
+
+    private fun get(path: String, headers: Map<String, List<String>> = emptyMap()): ScimHttpResponse =
+        dispatcher.dispatch(
+            ScimHttpRequest(
+                method = HttpMethod.GET,
+                path = "${basePath()}$path",
+                headers = headers
+            )
+        )
+
+    private fun put(path: String, body: ByteArray): ScimHttpResponse =
+        dispatcher.dispatch(
+            ScimHttpRequest(
+                method = HttpMethod.PUT,
+                path = "${basePath()}$path",
+                body = body,
+                headers = mapOf("Content-Type" to listOf("application/scim+json"))
+            )
+        )
+
+    private fun patch(path: String, body: ByteArray): ScimHttpResponse =
+        dispatcher.dispatch(
+            ScimHttpRequest(
+                method = HttpMethod.PATCH,
+                path = "${basePath()}$path",
+                body = body,
+                headers = mapOf("Content-Type" to listOf("application/scim+json"))
+            )
+        )
+
+    private fun delete(path: String): ScimHttpResponse =
+        dispatcher.dispatch(
+            ScimHttpRequest(
+                method = HttpMethod.DELETE,
+                path = "${basePath()}$path"
+            )
+        )
+
+    private fun postSearch(path: String, body: ByteArray): ScimHttpResponse =
+        dispatcher.dispatch(
+            ScimHttpRequest(
+                method = HttpMethod.POST,
+                path = "${basePath()}$path",
+                body = body,
+                headers = mapOf("Content-Type" to listOf("application/scim+json"))
+            )
+        )
+
+    private fun basePath(): String = "/scim/v2"
+
+    private fun parseJson(response: ScimHttpResponse): JsonNode =
+        objectMapper.readTree(response.body)
+}

--- a/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/contract/InMemoryScimApiContractTest.kt
+++ b/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/contract/InMemoryScimApiContractTest.kt
@@ -1,0 +1,66 @@
+package com.marcosbarbero.scim2.test.contract
+
+import com.marcosbarbero.scim2.core.domain.model.resource.Group
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.schema.introspector.SchemaRegistry
+import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
+import com.marcosbarbero.scim2.server.adapter.discovery.DiscoveryService
+import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
+import com.marcosbarbero.scim2.server.config.ScimServerConfig
+import com.marcosbarbero.scim2.test.handler.InMemoryResourceHandler
+import com.marcosbarbero.scim2.test.repository.InMemoryResourceRepository
+
+class InMemoryScimApiContractTest : ScimApiContractTest() {
+
+    private val objectMapper = JacksonScimSerializer.defaultObjectMapper()
+
+    override fun createDispatcher(): ScimEndpointDispatcher {
+        val userRepository = InMemoryResourceRepository<User> { user, id, meta ->
+            user.copy(id = id, meta = meta)
+        }
+        val groupRepository = InMemoryResourceRepository<Group> { group, id, meta ->
+            group.copy(id = id, meta = meta)
+        }
+
+        val userHandler = InMemoryResourceHandler(
+            resourceType = User::class.java,
+            endpoint = "/Users",
+            repository = userRepository
+        )
+        val groupHandler = InMemoryResourceHandler(
+            resourceType = Group::class.java,
+            endpoint = "/Groups",
+            repository = groupRepository
+        )
+
+        val schemaRegistry = SchemaRegistry().apply {
+            register(User::class)
+            register(Group::class)
+        }
+
+        val config = ScimServerConfig()
+        val serializer = JacksonScimSerializer()
+        val discoveryService = DiscoveryService(
+            handlers = listOf(userHandler, groupHandler),
+            schemaRegistry = schemaRegistry,
+            config = config
+        )
+
+        return ScimEndpointDispatcher(
+            handlers = listOf(userHandler, groupHandler),
+            bulkHandler = null,
+            meHandler = null,
+            discoveryService = discoveryService,
+            config = config,
+            serializer = serializer
+        )
+    }
+
+    override fun sampleUserJson(): ByteArray =
+        objectMapper.writeValueAsBytes(
+            mapOf(
+                "schemas" to listOf("urn:ietf:params:scim:schemas:core:2.0:User"),
+                "userName" to "john.doe"
+            )
+        )
+}


### PR DESCRIPTION
## Summary
- Add type-safe `ScimClient` extension functions (`createUser`, `getUser`, `searchUsers`, `patchUser`, `deleteUser`, `createGroup`, `getGroup`, etc.) plus generic `createResource<T>`, `getResource<T>`, `searchResources<T>` that read the endpoint from `@ScimResource` annotation
- Add `ScimClients` object with `@JvmStatic` methods for Java interop
- Add `ScimApiContractTest` abstract base class with 19 HTTP-level tests validating RFC 7644/7643 compliance (status codes, headers, body format), each referencing the specific RFC section
- Add `InMemoryScimApiContractTest` concrete implementation using `InMemoryResourceHandler` + `ScimEndpointDispatcher`
- Update README client usage section to show the new type-safe API for both Kotlin and Java

## Test plan
- [x] `ScimClientExtensionsTest` — 18 tests verifying extension functions delegate correctly (endpoint, type, filter construction, annotation reading, error on unannotated class)
- [x] `InMemoryScimApiContractTest` — 19 tests covering POST 201/Location/schemas/id+meta, GET 200/404/ScimError/ETag/304, PUT 200, PATCH 200, DELETE 204, GET search ListResponse, POST .search, discovery endpoints, Content-Type headers
- [x] Full build passes: `mvn clean verify -pl scim2-sdk-client,scim2-sdk-test -am`

🤖 Generated with [Claude Code](https://claude.com/claude-code)