### PR TITLE
docs: Module-level README files explaining purpose, architecture, and usage

### DIFF
--- a/scim2-sdk-bom/README.md
+++ b/scim2-sdk-bom/README.md
@@ -1,0 +1,25 @@
+# SCIM 2.0 SDK :: BOM (Bill of Materials)
+
+Import this BOM to manage all SCIM 2.0 SDK module versions consistently.
+
+## Usage
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.marcosbarbero</groupId>
+            <artifactId>scim2-sdk-bom</artifactId>
+            <version>${scim2-sdk.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<!-- Then use modules without version: -->
+<dependency>
+    <groupId>com.marcosbarbero</groupId>
+    <artifactId>scim2-sdk-core</artifactId>
+</dependency>
+```

--- a/scim2-sdk-client-httpclient/README.md
+++ b/scim2-sdk-client-httpclient/README.md
@@ -1,0 +1,19 @@
+# SCIM 2.0 SDK :: Client :: Java HttpClient
+
+`HttpTransport` adapter using Java's built-in `java.net.http.HttpClient` (Java 11+). This is the default transport -- zero additional dependencies.
+
+## Usage
+```kotlin
+val transport = JavaHttpClientTransport()
+// or with custom HttpClient:
+val transport = JavaHttpClientTransport(
+    HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .build()
+)
+
+val client = ScimClientBuilder()
+    .transport(transport)
+    // ...
+    .build()
+```

--- a/scim2-sdk-client-okhttp/README.md
+++ b/scim2-sdk-client-okhttp/README.md
@@ -1,0 +1,24 @@
+# SCIM 2.0 SDK :: Client :: OkHttp
+
+`HttpTransport` adapter using [OkHttp](https://square.github.io/okhttp/). Use this when you need OkHttp features like connection pooling, interceptors, or WebSocket support.
+
+## Usage
+```kotlin
+val transport = OkHttpTransport()
+// or with custom OkHttpClient:
+val transport = OkHttpTransport(
+    OkHttpClient.Builder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .addInterceptor(loggingInterceptor)
+        .build()
+)
+
+val client = ScimClientBuilder()
+    .transport(transport)
+    // ...
+    .build()
+```
+
+## Dependencies
+- `scim2-sdk-client`
+- `com.squareup.okhttp3:okhttp`

--- a/scim2-sdk-client/README.md
+++ b/scim2-sdk-client/README.md
@@ -1,0 +1,62 @@
+# SCIM 2.0 SDK :: Client
+
+Type-safe SCIM 2.0 client for consuming SCIM Service Provider APIs. Use this to provision users/groups programmatically.
+
+## Usage
+
+### Kotlin
+```kotlin
+val client = ScimClientBuilder()
+    .baseUrl("https://scim.example.com/scim/v2")
+    .transport(JavaHttpClientTransport())
+    .serializer(JacksonScimSerializer())
+    .authentication(BearerTokenAuthentication(token))
+    .build()
+
+// Type-safe operations
+val user = client.createUser(User(userName = "john.doe")).value
+val found = client.getUser(user.id!!).value
+client.patchUser(user.id!!, scimPatch { replace("displayName", "John") })
+val results = client.searchUsers("userName sw \"john\"")
+client.deleteUser(user.id!!)
+```
+
+### Java
+```java
+ScimClient client = new ScimClientBuilder()
+    .baseUrl("https://scim.example.com/scim/v2")
+    .transport(new JavaHttpClientTransport())
+    .serializer(new JacksonScimSerializer())
+    .authentication(new BearerTokenAuthentication(token))
+    .build();
+
+ScimResponse<User> response = ScimClients.createUser(client, user);
+ScimClients.deleteUser(client, id);
+```
+
+### Kotlin DSLs
+```kotlin
+// Filter DSL
+val filter = scimFilter { userName eq "john" and active.pr }
+
+// Patch DSL
+val patch = scimPatch { replace("displayName", "John"); remove("nickName") }
+
+// Search DSL
+val request = scimSearch { filter { userName sw "j" }; sortBy("userName"); count(25) }
+```
+
+### Async (Coroutines)
+```kotlin
+val asyncClient = AsyncScimClient(client)
+val user = asyncClient.createUser(user)
+```
+
+## Transport Adapters
+The client uses an `HttpTransport` SPI. Two adapters are provided:
+- `scim2-sdk-client-httpclient` -- Java 11+ HttpClient (default)
+- `scim2-sdk-client-okhttp` -- OkHttp
+
+## Dependencies
+- `scim2-sdk-core`
+- `kotlinx-coroutines-core` (for AsyncScimClient)

--- a/scim2-sdk-core/README.md
+++ b/scim2-sdk-core/README.md
@@ -1,0 +1,55 @@
+# SCIM 2.0 SDK :: Core
+
+The foundation module containing the SCIM 2.0 domain model, protocol types, filter/path parsing engine, PATCH operation engine, and serialization SPI. This module has **zero framework dependencies** -- only Kotlin stdlib, Kotlin reflect, and Jackson (optional).
+
+## What's in this module
+
+### Domain Model (RFC 7643)
+Pre-built Kotlin data classes for all SCIM 2.0 resource types:
+- `User` -- all RFC 7643 attributes (userName, name, emails, phoneNumbers, addresses, etc.)
+- `Group` -- displayName, members
+- `EnterpriseUserExtension` -- employeeNumber, department, manager, etc.
+- `ScimResource` -- abstract base class for all resources
+
+### Protocol Types (RFC 7644)
+- `PatchRequest` / `PatchOperation` -- SCIM PATCH operations
+- `SearchRequest` / `ListResponse` -- search queries and paginated results
+- `BulkRequest` / `BulkResponse` -- bulk operations
+- `ScimError` / `ScimProblemDetail` -- error responses (RFC 7644 + RFC 9457)
+
+### Filter Parser
+A complete recursive-descent parser for SCIM filter expressions:
+```kotlin
+val filter = FilterParser.parse("userName eq \"john\" and active eq true")
+// Produces an AST: LogicalExpression(AND, AttributeExpression(...), AttributeExpression(...))
+```
+Includes `FilterVisitor<T>` for transforming filters (to SQL, to predicates, to string, etc.)
+
+### Path Parser
+Parses SCIM PATCH path expressions:
+```kotlin
+val path = PathParser.parse("emails[type eq \"work\"].value")
+// FilteredPath(attributeName="emails", filter=..., subAttribute="value")
+```
+
+### PATCH Engine
+Applies SCIM PATCH operations to resources immutably:
+```kotlin
+val engine = PatchEngine(objectMapper)
+val updated = engine.apply(user, patchRequest)
+```
+
+### Serialization SPI
+`ScimSerializer` interface with `JacksonScimSerializer` as the default implementation.
+
+### Event & Observability SPIs
+- `ScimEvent` sealed hierarchy (created, replaced, patched, deleted)
+- `ScimEventPublisher` -- publish events after SCIM operations
+- `ScimMetrics` / `ScimTracer` -- observability hooks
+
+## Dependencies
+- `kotlin-stdlib`, `kotlin-reflect`
+- `jackson-databind`, `jackson-module-kotlin`, `jackson-datatype-jsr310` (all optional)
+- `slf4j-api`
+
+No Spring, no HTTP framework, no database dependencies.

--- a/scim2-sdk-server/README.md
+++ b/scim2-sdk-server/README.md
@@ -1,0 +1,94 @@
+# SCIM 2.0 SDK :: Server
+
+This module provides the **SCIM Service Provider** framework -- the server-side implementation that receives and processes identity provisioning requests from Identity Providers (IdPs).
+
+## What is a SCIM Service Provider?
+
+When organizations use IdPs like **Okta**, **Azure AD**, **Keycloak**, or **PingFederate**, those IdPs need to push user/group changes to your application. The SCIM 2.0 protocol (RFC 7644) standardizes this:
+
+```
++----------------+    SCIM 2.0 Protocol    +-----------------------+
+|  Identity      |  ---- POST /Users --->  |  Your Application     |
+|  Provider      |  ---- PATCH /Users -->  |  (SCIM Service        |
+|  (Okta,        |  ---- DELETE /Users ->  |   Provider, using     |
+|   Azure AD)    |  <--- 201 Created ----  |   this SDK)           |
++----------------+                          +-----------------------+
+```
+
+For example, when a new employee joins and is added in Okta, Okta sends a `POST /scim/v2/Users` request to your application. This module handles that request.
+
+See: [Okta SCIM Integration Guide](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_scim.htm)
+
+## Architecture (Hexagonal)
+
+```
++------------------- Inbound -------------------+
+|  ScimController (Spring MVC)                   |
+|  JDK HttpServer (plain Kotlin)                 |
+|  Any HTTP framework                            |
++--------------------+---------------------------+
+                     |
+         +-----------v--------------+
+         |  ScimEndpointDispatcher  | <-- Central routing engine
+         |  (framework-agnostic)    |
+         +-----------+--------------+
+                     |
++--------------------+-------------------------+
+|  Inbound Ports     |     Outbound Ports       |
+|  ResourceHandler   |     ResourceRepository   |
+|  BulkHandler       |     IdentityResolver     |
+|  MeHandler         |     AuthorizationEval.   |
+|                    |     ScimEventPublisher    |
+|                    |     ScimOutboxPort        |
++--------------------+-------------------------+
+                     |
++--------------------v-------------------------+
+|  Your Implementation                          |
+|  (JPA, MongoDB, DynamoDB, custom...)          |
++-----------------------------------------------+
+```
+
+## Key Interfaces
+
+### ResourceHandler<T> (you implement this)
+Handles CRUD + search for a specific resource type:
+```kotlin
+class MyUserHandler : ResourceHandler<User> {
+    override val resourceType = User::class.java
+    override val endpoint = "/Users"
+    override fun create(resource: User, context: ScimRequestContext): User { ... }
+    override fun get(id: ResourceId, context: ScimRequestContext): User { ... }
+    // ... replace, patch, delete, search
+}
+```
+
+### ResourceRepository<T> (persistence abstraction)
+Generic persistence port -- no database opinion:
+```kotlin
+class MyUserRepository : ResourceRepository<User> {
+    override fun create(resource: User): User { ... }
+    override fun findById(id: String): User? { ... }
+    // ... replace, delete, search
+}
+```
+
+### IdentityResolver (authentication)
+Extracts the authenticated identity from the incoming request:
+```kotlin
+class MyIdentityResolver : IdentityResolver {
+    override fun resolve(request: ScimHttpRequest): ScimRequestContext { ... }
+}
+```
+
+### ScimEndpointDispatcher
+Routes all SCIM HTTP requests to the appropriate handler. Supports all RFC 7644 endpoints:
+- `POST /Users`, `GET /Users/{id}`, `PUT`, `PATCH`, `DELETE`
+- `GET /Users?filter=...`, `POST /Users/.search`
+- `POST /Bulk`
+- `GET /ServiceProviderConfig`, `/Schemas`, `/ResourceTypes`
+- `GET|PUT|PATCH|DELETE /Me`
+- Case-insensitive routing (`/users` = `/Users`)
+
+## Dependencies
+- `scim2-sdk-core`
+- No Spring, no HTTP framework, no database

--- a/scim2-sdk-spring-boot-autoconfigure/README.md
+++ b/scim2-sdk-spring-boot-autoconfigure/README.md
@@ -1,0 +1,50 @@
+# SCIM 2.0 SDK :: Spring Boot Auto-Configuration
+
+Auto-configures the SCIM 2.0 SDK for Spring Boot applications. Provides sensible defaults with full customization via properties and `@ConditionalOnMissingBean` back-off.
+
+## What gets auto-configured
+
+| Feature | Condition | Property |
+|---|---|---|
+| SCIM endpoints (`/scim/v2/*`) | `ScimEndpointDispatcher` on classpath | `scim.base-path` |
+| JPA persistence | JPA on classpath | `scim.persistence.enabled=true` |
+| Flyway migration | Flyway on classpath | `scim.persistence.auto-migrate=true` |
+| SCIM client | -- | `scim.client.base-url` |
+| IdP adapter | Spring Security OAuth2 on classpath | `scim.idp.provider` |
+| Micrometer metrics | Micrometer on classpath | automatic |
+| Jackson serialization | Jackson on classpath | automatic |
+
+## IdP Adapters
+
+Configure your Identity Provider for JWT-based authentication:
+
+```yaml
+scim:
+  idp:
+    provider: keycloak  # keycloak, okta, azure-ad, ping-federate, auth0
+    client-id: my-app   # for Keycloak client roles
+    claims:              # override default claim names
+      subject: sub
+      roles: realm_access
+      email: email
+```
+
+Supported providers: Keycloak, Okta, Azure AD (Entra ID), PingFederate, Auth0.
+
+All claim names are configurable via `scim.idp.claims.*`. Provide your own `IdentityResolver` bean to replace any adapter.
+
+## Persistence
+
+```yaml
+scim:
+  persistence:
+    enabled: true           # enable JPA-backed storage
+    table-name: scim_resources  # customize table name
+    schema-name: my_schema  # optional DB schema
+    auto-migrate: true      # run Flyway migration on startup
+```
+
+Reference SQL schemas for PostgreSQL, MySQL, Oracle, MSSQL, H2 are in `src/main/resources/db/scim/`.
+
+## Every bean backs off
+Every auto-configured bean uses `@ConditionalOnMissingBean`. Provide your own implementation and the auto-configured one disappears.

--- a/scim2-sdk-spring-boot-starter/README.md
+++ b/scim2-sdk-spring-boot-starter/README.md
@@ -1,0 +1,33 @@
+# SCIM 2.0 SDK :: Spring Boot Starter
+
+Convenience starter that aggregates all dependencies needed for a Spring Boot SCIM Service Provider.
+
+## Usage
+
+Just add this single dependency:
+
+```xml
+<dependency>
+    <groupId>com.marcosbarbero</groupId>
+    <artifactId>scim2-sdk-spring-boot-starter</artifactId>
+    <version>${scim2-sdk.version}</version>
+</dependency>
+```
+
+This pulls in:
+- `scim2-sdk-core` -- domain model and parsing
+- `scim2-sdk-server` -- endpoint dispatcher
+- `scim2-sdk-client` -- SCIM client
+- `scim2-sdk-client-httpclient` -- default HTTP transport
+- `scim2-sdk-spring-boot-autoconfigure` -- auto-configuration
+- `spring-boot-starter` -- Spring Boot baseline
+
+Configure via `application.yml`:
+```yaml
+scim:
+  base-path: /scim/v2
+  persistence:
+    enabled: true
+```
+
+See [scim2-sdk-spring-boot-autoconfigure](../scim2-sdk-spring-boot-autoconfigure/) for all configuration options.

--- a/scim2-sdk-test/README.md
+++ b/scim2-sdk-test/README.md
@@ -1,0 +1,59 @@
+# SCIM 2.0 SDK :: Test
+
+Test utilities, contract test base classes, and in-memory implementations for testing SCIM integrations.
+
+## In-Memory Implementations
+
+### InMemoryResourceRepository
+A `ConcurrentHashMap`-backed `ResourceRepository<T>` for testing:
+```kotlin
+val repo = InMemoryResourceRepository<User>()
+```
+
+### InMemoryResourceHandler
+A `ResourceHandler<T>` backed by `InMemoryResourceRepository`:
+```kotlin
+val handler = InMemoryResourceHandler(User::class.java, "/Users", repo)
+```
+
+### InMemoryScimServer
+A complete SCIM server for integration testing:
+```kotlin
+val server = InMemoryScimServer()
+server.createUser(User(userName = "test"))
+val response = server.dispatch(ScimHttpRequest(GET, "/scim/v2/Users"))
+```
+
+## Contract Tests
+
+### ResourceHandlerContractTest
+Abstract base class with 23 tests. Extend it to prove your `ResourceHandler` implementation is correct:
+```kotlin
+class MyUserHandlerTest : ResourceHandlerContractTest<User>() {
+    override fun createHandler() = MyUserHandler()
+    override fun sampleResource() = User(userName = "test")
+    override fun modifiedResource(original: User) = original.copy(displayName = "Modified")
+}
+```
+
+### ScimApiContractTest
+Abstract base class with 19 HTTP-level tests validating RFC 7644/7643 compliance. Each test references the specific RFC section:
+```kotlin
+class MyApiContractTest : ScimApiContractTest() {
+    override fun createDispatcher() = myDispatcher
+    override fun sampleUserJson() = serializer.serialize(User(userName = "test"))
+}
+```
+
+Tests include:
+- `POST returns 201 Created (RFC 7644 S3.1)`
+- `POST response includes Location header (RFC 7644 S3.1)`
+- `GET returns ETag header (RFC 7644 S3.14)`
+- `GET with If-None-Match returns 304 (RFC 7644 S3.14)`
+- `DELETE returns 204 No Content (RFC 7644 S3.6)`
+- ... and more
+
+## ArchUnit Tests
+Validates architectural boundaries:
+- Core module has no Spring/server/client dependencies
+- Server module has no client/Spring dependencies


### PR DESCRIPTION
Every module now has its own README.md explaining what it does, how it fits in the architecture, and how to use it. The server module README explains the SCIM Service Provider concept with real-world IdP integration context.