### PR TITLE
refactor: Idiomatic Kotlin null handling, Java interop fix, outbox adapter docs

### DIFF
--- a/docs/adr/0023-namastack-outbox-integration.md
+++ b/docs/adr/0023-namastack-outbox-integration.md
@@ -1,0 +1,44 @@
+# ADR-0023: namastack-outbox Integration
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-25
+
+## Context
+
+The SCIM SDK publishes domain events (`ScimEvent`) through the `ScimEventPublisher` SPI. For production deployments, the transactional outbox pattern is the recommended approach to ensure reliable event delivery. The `ScimOutboxPort` interface was introduced to decouple the outbox storage mechanism from the SDK.
+
+[namastack-outbox](https://github.com/namastack/namastack-outbox) is a transactional outbox library that integrates with Spring Modulith and supports multiple message brokers (Kafka, SQS, etc.). It provides exactly-once delivery semantics by storing events in the same database transaction as the business operation and relaying them asynchronously.
+
+## Decision
+
+We provide namastack-outbox integration as a **documented adapter pattern** rather than a compiled module dependency, because:
+
+1. **namastack-outbox may not yet be in Maven Central** -- adding a hard compile dependency would prevent users from building the SDK.
+2. **The adapter is minimal** -- it is a single class (~30 lines) that maps `ScimEvent` to namastack-outbox's `OutboxMessage`.
+3. **Users may prefer other outbox implementations** (Debezium, custom JDBC, Spring Modulith events) and forcing a specific one violates the SDK's "no opinions on infrastructure" principle (see ADR-0001).
+
+The adapter code is documented in `docs/outbox-pattern.md` under "Option 1: namastack-outbox". Once namastack-outbox reaches a stable Maven Central release, we may promote this to a dedicated `scim2-sdk-outbox-namastack` module.
+
+### Mapping Strategy
+
+| ScimEvent field     | OutboxMessage field |
+|---------------------|---------------------|
+| `resourceId`        | `aggregateId`       |
+| `"ScimResource"`    | `aggregateType`     |
+| class simple name   | `eventType`         |
+| JSON serialization  | `payload`           |
+| `correlationId`     | header              |
+| `resourceType`      | header              |
+| `eventId`           | header              |
+
+## Consequences
+
+- Users who want namastack-outbox integration copy the adapter from the docs into their project.
+- No new compile-time dependency is introduced.
+- When namastack-outbox is available in Maven Central, we can create a proper module with auto-configuration and a `@ConditionalOnClass` guard.
+- The `ScimOutboxPort` SPI remains the stable contract; adapter implementations are interchangeable.

--- a/docs/outbox-pattern.md
+++ b/docs/outbox-pattern.md
@@ -60,6 +60,58 @@ scim:
 
 The SDK auto-configures a `NamastackOutboxAdapter` that implements `ScimOutboxPort` and delegates to namastack-outbox's `OutboxPublisher`.
 
+#### Adapter Code
+
+Since namastack-outbox may not yet be available in Maven Central, you can create the adapter manually in your project:
+
+```kotlin
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.marcosbarbero.scim2.core.event.ScimEvent
+import com.marcosbarbero.scim2.server.port.ScimOutboxPort
+// import com.namastack.outbox.OutboxPublisher  // from namastack-outbox
+import org.springframework.stereotype.Component
+
+/**
+ * Bridges [ScimOutboxPort] to namastack-outbox's [OutboxPublisher].
+ *
+ * Each [ScimEvent] is mapped to an outbox message with:
+ * - aggregateType = "ScimResource"
+ * - aggregateId   = event.resourceId
+ * - eventType     = event's simple class name (e.g., "ResourceCreatedEvent")
+ * - payload       = JSON-serialized event
+ *
+ * namastack-outbox handles persistence in the same DB transaction and
+ * asynchronous relay to the configured message broker (Kafka, SQS, etc.).
+ */
+@Component
+class NamastackOutboxAdapter(
+    private val outboxPublisher: Any, // OutboxPublisher — replace with actual type
+    private val objectMapper: ObjectMapper
+) : ScimOutboxPort {
+
+    override fun store(event: ScimEvent) {
+        val payload = objectMapper.writeValueAsString(event)
+
+        // Replace with actual namastack-outbox API call:
+        // outboxPublisher.publish(
+        //     OutboxMessage(
+        //         aggregateType = "ScimResource",
+        //         aggregateId = event.resourceId,
+        //         eventType = event::class.simpleName ?: "ScimEvent",
+        //         payload = payload,
+        //         headers = buildMap {
+        //             put("correlationId", event.correlationId ?: "")
+        //             put("resourceType", event.resourceType)
+        //             put("eventId", event.eventId)
+        //         }
+        //     )
+        // )
+    }
+}
+```
+
+Once namastack-outbox is published, replace the commented section with the actual API call and update the `outboxPublisher` type to `OutboxPublisher`.
+
 ### Option 2: Custom Implementation
 
 Implement `ScimOutboxPort` and register as a Spring bean:

--- a/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClient.kt
+++ b/scim2-sdk-client/src/main/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClient.kt
@@ -128,9 +128,7 @@ internal class DefaultScimClient(
         val headers = buildMap {
             putAll(defaultHeaders)
             put(ACCEPT, SCIM_MEDIA_TYPE)
-            if (body != null) {
-                put(CONTENT_TYPE, SCIM_MEDIA_TYPE)
-            }
+            body?.let { put(CONTENT_TYPE, SCIM_MEDIA_TYPE) }
         }
         return HttpRequest(method = method, url = url, headers = headers, body = body)
     }

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/AttributePath.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/ast/AttributePath.kt
@@ -6,14 +6,14 @@ data class AttributePath(
     val subAttribute: String? = null
 ) {
     fun toFullPath(): String = buildString {
-        if (schemaUri != null) {
-            append(schemaUri)
+        schemaUri?.let {
+            append(it)
             append(":")
         }
         append(attributeName)
-        if (subAttribute != null) {
+        subAttribute?.let {
             append(".")
-            append(subAttribute)
+            append(it)
         }
     }
 }

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToPredicateVisitor.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/filter/visitor/FilterToPredicateVisitor.kt
@@ -37,13 +37,11 @@ class FilterToPredicateVisitor : FilterVisitor<(Map<String, Any?>) -> Boolean> {
         if (collection is List<*>) {
             val innerPredicate = visit(node.filter)
             val matchingItems = collection.filterIsInstance<Map<String, Any?>>().filter { innerPredicate(it) }
-            if (node.subAttribute != null) {
+            node.subAttribute?.let { subAttr ->
                 // There's a sub-attribute + outer comparison - but as a standalone value path,
                 // just check that matching items exist with that sub-attribute
-                matchingItems.any { it.containsKey(node.subAttribute) }
-            } else {
-                matchingItems.isNotEmpty()
-            }
+                matchingItems.any { it.containsKey(subAttr) }
+            } ?: matchingItems.isNotEmpty()
         } else {
             false
         }

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngine.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngine.kt
@@ -35,23 +35,16 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
         val path = operation.path
         val value = operation.value
 
-        if (path == null) {
+        path ?: run {
             // No path: value must be an object, merge its attributes into the resource
-            if (value is ObjectNode) {
-                val fieldNames = value.fieldNames()
-                while (fieldNames.hasNext()) {
-                    val fieldName = fieldNames.next()
-                    node.set<com.fasterxml.jackson.databind.JsonNode>(fieldName, value.get(fieldName))
-                }
-            } else {
-                throw InvalidValueException("ADD operation with no path requires an object value")
-            }
+            (value as? ObjectNode)?.fieldNames()?.forEach { fieldName ->
+                node.set<com.fasterxml.jackson.databind.JsonNode>(fieldName, value.get(fieldName))
+            } ?: throw InvalidValueException("ADD operation with no path requires an object value")
             return node
         }
 
         // Check for value path filter (e.g., emails[type eq "work"])
-        val filterMatch = FILTER_PATH_REGEX.matchEntire(path)
-        if (filterMatch != null) {
+        FILTER_PATH_REGEX.matchEntire(path)?.let { filterMatch ->
             val attrName = filterMatch.groupValues[1]
             val filterAttr = filterMatch.groupValues[2]
             val filterValue = filterMatch.groupValues[3]
@@ -64,11 +57,7 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
         if (existing != null && existing.isArray) {
             // Append to existing array
             val array = existing as ArrayNode
-            if (value != null && value.isArray) {
-                value.forEach { array.add(it) }
-            } else {
-                array.add(value)
-            }
+            value?.takeIf { it.isArray }?.forEach { array.add(it) } ?: array.add(value)
         } else {
             node.set<com.fasterxml.jackson.databind.JsonNode>(path, value)
         }
@@ -79,8 +68,7 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
         val path = operation.path
             ?: throw InvalidPathException("REMOVE operation requires a path")
 
-        val filterMatch = FILTER_PATH_REGEX.matchEntire(path)
-        if (filterMatch != null) {
+        FILTER_PATH_REGEX.matchEntire(path)?.let { filterMatch ->
             val attrName = filterMatch.groupValues[1]
             val filterAttr = filterMatch.groupValues[2]
             val filterValue = filterMatch.groupValues[3]
@@ -96,17 +84,11 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
         val path = operation.path
         val value = operation.value
 
-        if (path == null) {
+        path ?: run {
             // No path: value must be an object, replace its attributes
-            if (value is ObjectNode) {
-                val fieldNames = value.fieldNames()
-                while (fieldNames.hasNext()) {
-                    val fieldName = fieldNames.next()
-                    node.set<com.fasterxml.jackson.databind.JsonNode>(fieldName, value.get(fieldName))
-                }
-            } else {
-                throw InvalidValueException("REPLACE operation with no path requires an object value")
-            }
+            (value as? ObjectNode)?.fieldNames()?.forEach { fieldName ->
+                node.set<com.fasterxml.jackson.databind.JsonNode>(fieldName, value.get(fieldName))
+            } ?: throw InvalidValueException("REPLACE operation with no path requires an object value")
             return node
         }
 
@@ -126,13 +108,9 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
             val element = array.get(i) as? ObjectNode ?: continue
             val fieldValue = element.get(filterAttr)?.asText()
             if (fieldValue.equals(filterValue, ignoreCase = true)) {
-                if (value is ObjectNode) {
-                    value.fieldNames().forEach { field ->
-                        element.set<com.fasterxml.jackson.databind.JsonNode>(field, value.get(field))
-                    }
-                } else {
-                    throw InvalidValueException("Filtered multi-valued attribute update requires an object value")
-                }
+                (value as? ObjectNode)?.fieldNames()?.forEach { field ->
+                    element.set<com.fasterxml.jackson.databind.JsonNode>(field, value.get(field))
+                } ?: throw InvalidValueException("Filtered multi-valued attribute update requires an object value")
             }
         }
     }

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaIntrospector.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/schema/introspector/SchemaIntrospector.kt
@@ -77,7 +77,7 @@ class SchemaIntrospector {
 
         return SchemaAttribute(
             name = annotation?.name?.takeIf { it.isNotEmpty() } ?: property.name,
-            type = if (annotation != null) annotation.type else attrType,
+            type = annotation?.type ?: attrType,
             multiValued = isMultiValued,
             description = annotation?.description ?: "",
             required = annotation?.required ?: false,

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/validation/ScimValidator.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/validation/ScimValidator.kt
@@ -34,7 +34,7 @@ class ScimValidator {
         }
 
         // Also check common readOnly fields not annotated
-        if (resource.id != null) {
+        resource.id?.let {
             errors.add("Attribute 'id' is readOnly and should not be set by client")
         }
 

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcher.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcher.kt
@@ -5,7 +5,6 @@ import com.marcosbarbero.scim2.core.domain.model.error.ScimException
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.core.event.BulkOperationCompletedEvent
 import com.marcosbarbero.scim2.core.event.NoOpEventPublisher
 import com.marcosbarbero.scim2.core.event.ResourceCreatedEvent
@@ -111,8 +110,7 @@ class ScimEndpointDispatcher(
     }
 
     private fun resolveEndpoint(relativePath: String): String {
-        val handler = findHandler(relativePath)
-        if (handler != null) return handler.endpoint
+        findHandler(relativePath)?.let { return it.endpoint }
         val lower = relativePath.lowercase()
         return when {
             lower.startsWith("/serviceproviderconfig") -> "/ServiceProviderConfig"
@@ -125,8 +123,7 @@ class ScimEndpointDispatcher(
     }
 
     private fun resolveResourceType(relativePath: String): String {
-        val handler = findHandler(relativePath)
-        if (handler != null) return handler.resourceType.simpleName ?: "Unknown"
+        findHandler(relativePath)?.let { return it.resourceType.simpleName ?: "Unknown" }
         val lower = relativePath.lowercase()
         return when {
             lower == "/bulk" -> "Bulk"
@@ -231,7 +228,7 @@ class ScimEndpointDispatcher(
             }
 
             HttpMethod.GET -> {
-                if (resourceId == null || resourceId.isEmpty()) {
+                if (resourceId.isNullOrEmpty()) {
                     // Search via GET
                     requireAuthorization { it.canSearch(handler.endpoint, context) }
                     val searchRequest = request.toSearchRequest()
@@ -239,7 +236,7 @@ class ScimEndpointDispatcher(
                     ok(result)
                 } else {
                     requireAuthorization { it.canRead(handler.endpoint, resourceId, context) }
-                    val result = handler.get(ResourceId(resourceId), context)
+                    val result = handler.get(resourceId, context)
                     val etag = etagEngine.generateETag(result)
                     val ifNoneMatch = etagEngine.extractIfNoneMatch(request)
                     if (ifNoneMatch != null && etag == ifNoneMatch) {
@@ -258,7 +255,7 @@ class ScimEndpointDispatcher(
                 requireAuthorization { it.canUpdate(handler.endpoint, resourceId, context) }
                 val ifMatch = etagEngine.extractIfMatch(request)
                 val resource = deserializeBody(request, handler.resourceType)
-                val result = handler.replace(ResourceId(resourceId), resource, ifMatch, context)
+                val result = handler.replace(resourceId, resource, ifMatch?.value, context)
                 eventPublisher.publish(
                     ResourceReplacedEvent(
                         resourceType = resourceTypeName,
@@ -274,7 +271,7 @@ class ScimEndpointDispatcher(
                 requireAuthorization { it.canUpdate(handler.endpoint, resourceId, context) }
                 val ifMatch = etagEngine.extractIfMatch(request)
                 val patchRequest = deserializeBody<PatchRequest>(request)
-                val result = handler.patch(ResourceId(resourceId), patchRequest, ifMatch, context)
+                val result = handler.patch(resourceId, patchRequest, ifMatch?.value, context)
                 eventPublisher.publish(
                     ResourcePatchedEvent(
                         resourceType = resourceTypeName,
@@ -290,7 +287,7 @@ class ScimEndpointDispatcher(
                 requireNotNull(resourceId) { "DELETE requires a resource ID" }
                 requireAuthorization { it.canDelete(handler.endpoint, resourceId, context) }
                 val ifMatch = etagEngine.extractIfMatch(request)
-                handler.delete(ResourceId(resourceId), ifMatch, context)
+                handler.delete(resourceId, ifMatch?.value, context)
                 eventPublisher.publish(
                     ResourceDeletedEvent(
                         resourceType = resourceTypeName,
@@ -317,20 +314,20 @@ class ScimEndpointDispatcher(
             HttpMethod.PUT -> {
                 val ifMatch = etagEngine.extractIfMatch(request)
                 val resource = deserializeBody<ScimResource>(request)
-                val result = handler.replaceMe(context, resource, ifMatch)
+                val result = handler.replaceMe(context, resource, ifMatch?.value)
                 ok(result)
             }
 
             HttpMethod.PATCH -> {
                 val ifMatch = etagEngine.extractIfMatch(request)
                 val patchRequest = deserializeBody<PatchRequest>(request)
-                val result = handler.patchMe(context, patchRequest, ifMatch)
+                val result = handler.patchMe(context, patchRequest, ifMatch?.value)
                 ok(result)
             }
 
             HttpMethod.DELETE -> {
                 val ifMatch = etagEngine.extractIfMatch(request)
-                handler.deleteMe(context, ifMatch)
+                handler.deleteMe(context, ifMatch?.value)
                 ScimHttpResponse.noContent()
             }
 
@@ -351,18 +348,13 @@ class ScimEndpointDispatcher(
             ?.map { it.trim() }
             ?: emptyList()
 
-        return if (identityResolver != null) {
-            val resolved = identityResolver.resolve(this)
-            resolved.copy(
-                requestedAttributes = requestedAttrs,
-                excludedAttributes = excludedAttrs
-            )
-        } else {
-            ScimRequestContext(
-                requestedAttributes = requestedAttrs,
-                excludedAttributes = excludedAttrs
-            )
-        }
+        return identityResolver?.resolve(this)?.copy(
+            requestedAttributes = requestedAttrs,
+            excludedAttributes = excludedAttrs
+        ) ?: ScimRequestContext(
+            requestedAttributes = requestedAttrs,
+            excludedAttributes = excludedAttrs
+        )
     }
 
     private fun ScimHttpRequest.toSearchRequest(): SearchRequest =

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/engine/BulkEngine.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/engine/BulkEngine.kt
@@ -6,7 +6,7 @@ import com.marcosbarbero.scim2.core.domain.model.bulk.BulkRequest
 import com.marcosbarbero.scim2.core.domain.model.bulk.BulkResponse
 import com.marcosbarbero.scim2.core.domain.model.error.ScimException
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
+
 import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
 import com.marcosbarbero.scim2.server.config.ScimServerConfig
 import com.marcosbarbero.scim2.server.port.ResourceHandler
@@ -55,15 +55,12 @@ class BulkEngine(
         val method = operation.method.uppercase()
         val path = resolveBulkIdReferences(operation.path ?: "", bulkIdMap)
         val handler = findHandler(path) as? ResourceHandler<ScimResource>
-
-        if (handler == null) {
-            return BulkOperationResponse(
+            ?: return BulkOperationResponse(
                 method = method,
                 bulkId = operation.bulkId,
                 status = "404",
                 location = null
             )
-        }
 
         return try {
             when (method) {
@@ -77,8 +74,8 @@ class BulkEngine(
                     val created = handler.create(resource, context)
                     val location = "${config.basePath}${handler.endpoint}/${created.id}"
                     val opBulkId = operation.bulkId
-                    if (opBulkId != null && created.id != null) {
-                        bulkIdMap[opBulkId] = created.id!!
+                    if (opBulkId != null) {
+                        created.id?.let { bulkIdMap[opBulkId] = it }
                     }
                     BulkOperationResponse(
                         method = method,
@@ -96,7 +93,7 @@ class BulkEngine(
                         serializer.serialize(data),
                         handler.resourceType.kotlin
                     )
-                    handler.replace(ResourceId(resourceId), resource, null, context)
+                    handler.replace(resourceId, resource, null, context)
                     val location = "${config.basePath}${handler.endpoint}/$resourceId"
                     BulkOperationResponse(
                         method = method,
@@ -112,7 +109,7 @@ class BulkEngine(
                         serializer.serialize(operation.data!!),
                         com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest::class
                     )
-                    handler.patch(ResourceId(resourceId), patchRequest, null, context)
+                    handler.patch(resourceId, patchRequest, null, context)
                     val location = "${config.basePath}${handler.endpoint}/$resourceId"
                     BulkOperationResponse(
                         method = method,
@@ -124,7 +121,7 @@ class BulkEngine(
 
                 "DELETE" -> {
                     val resourceId = extractResourceId(path, handler.endpoint)
-                    handler.delete(ResourceId(resourceId), null, context)
+                    handler.delete(resourceId, null, context)
                     BulkOperationResponse(
                         method = method,
                         bulkId = operation.bulkId,
@@ -167,8 +164,7 @@ class BulkEngine(
         val regex = Regex("bulkId:([^/\"\\s]+)")
         regex.findAll(path).forEach { match ->
             val bulkId = match.groupValues[1]
-            val resourceId = bulkIdMap[bulkId]
-            if (resourceId != null) {
+            bulkIdMap[bulkId]?.let { resourceId ->
                 resolved = resolved.replace("bulkId:$bulkId", resourceId)
             }
         }

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/engine/ETagEngine.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/engine/ETagEngine.kt
@@ -8,9 +8,7 @@ import com.marcosbarbero.scim2.server.http.ScimHttpRequest
 class ETagEngine {
 
     fun generateETag(resource: ScimResource): ETag {
-        val version = resource.meta?.version
-        if (version != null) return version
-
+        resource.meta?.version?.let { return it }
         val hash = resource.hashCode().toUInt().toString(16)
         return ETag("W/\"$hash\"")
     }
@@ -26,8 +24,8 @@ class ETagEngine {
     }
 
     fun checkPrecondition(current: ETag?, required: ETag?): Boolean {
-        if (required == null) return true
-        if (current == null) return true
+        required ?: return true
+        current ?: return true
         return current == required
     }
 

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/port/MeHandler.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/port/MeHandler.kt
@@ -2,15 +2,14 @@ package com.marcosbarbero.scim2.server.port
 
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
-import com.marcosbarbero.scim2.core.domain.vo.ETag
 
 interface MeHandler<T : ScimResource> {
 
     fun getMe(context: ScimRequestContext): T
 
-    fun replaceMe(context: ScimRequestContext, resource: T, version: ETag?): T
+    fun replaceMe(context: ScimRequestContext, resource: T, version: String?): T
 
-    fun patchMe(context: ScimRequestContext, request: PatchRequest, version: ETag?): T
+    fun patchMe(context: ScimRequestContext, request: PatchRequest, version: String?): T
 
-    fun deleteMe(context: ScimRequestContext, version: ETag?)
+    fun deleteMe(context: ScimRequestContext, version: String?)
 }

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/port/ResourceHandler.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/port/ResourceHandler.kt
@@ -4,8 +4,6 @@ import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 
 interface ResourceHandler<T : ScimResource> {
 
@@ -13,15 +11,15 @@ interface ResourceHandler<T : ScimResource> {
 
     val endpoint: String
 
-    fun get(id: ResourceId, context: ScimRequestContext): T
+    fun get(id: String, context: ScimRequestContext): T
 
     fun create(resource: T, context: ScimRequestContext): T
 
-    fun replace(id: ResourceId, resource: T, version: ETag?, context: ScimRequestContext): T
+    fun replace(id: String, resource: T, version: String?, context: ScimRequestContext): T
 
-    fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): T
+    fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): T
 
-    fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext)
+    fun delete(id: String, version: String?, context: ScimRequestContext)
 
     fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<T>
 }

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/port/ResourceRepository.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/port/ResourceRepository.kt
@@ -3,18 +3,16 @@ package com.marcosbarbero.scim2.server.port
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 
 interface ResourceRepository<T : ScimResource> {
 
-    fun findById(id: ResourceId): T?
+    fun findById(id: String): T?
 
     fun create(resource: T): T
 
-    fun replace(id: ResourceId, resource: T, version: ETag?): T
+    fun replace(id: String, resource: T, version: String?): T
 
-    fun delete(id: ResourceId, version: ETag?)
+    fun delete(id: String, version: String?)
 
     fun search(request: SearchRequest): ListResponse<T>
 }

--- a/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
+++ b/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
@@ -16,8 +16,6 @@ import com.marcosbarbero.scim2.core.domain.model.resource.Group
 import com.marcosbarbero.scim2.core.domain.model.resource.User
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.core.event.ResourceCreatedEvent
 import com.marcosbarbero.scim2.core.event.ResourceDeletedEvent
 import com.marcosbarbero.scim2.core.event.ResourcePatchedEvent
@@ -68,8 +66,8 @@ class ScimEndpointDispatcherTest {
         override val resourceType: Class<User> = User::class.java
         override val endpoint: String = "/Users"
 
-        override fun get(id: ResourceId, context: ScimRequestContext): User =
-            users[id.value] ?: throw ResourceNotFoundException("User not found: ${id.value}")
+        override fun get(id: String, context: ScimRequestContext): User =
+            users[id] ?: throw ResourceNotFoundException("User not found: $id")
 
         override fun create(resource: User, context: ScimRequestContext): User {
             val id = java.util.UUID.randomUUID().toString()
@@ -78,22 +76,22 @@ class ScimEndpointDispatcherTest {
             return created
         }
 
-        override fun replace(id: ResourceId, resource: User, version: ETag?, context: ScimRequestContext): User {
-            if (!users.containsKey(id.value)) throw ResourceNotFoundException("User not found: ${id.value}")
-            val replaced = resource.copy(id = id.value)
-            users[id.value] = replaced
+        override fun replace(id: String, resource: User, version: String?, context: ScimRequestContext): User {
+            if (!users.containsKey(id)) throw ResourceNotFoundException("User not found: $id")
+            val replaced = resource.copy(id = id)
+            users[id] = replaced
             return replaced
         }
 
-        override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): User {
-            val existing = users[id.value] ?: throw ResourceNotFoundException("User not found: ${id.value}")
+        override fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): User {
+            val existing = users[id] ?: throw ResourceNotFoundException("User not found: $id")
             // Simple patch: just return existing for test purposes
             return existing
         }
 
-        override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) {
-            if (!users.containsKey(id.value)) throw ResourceNotFoundException("User not found: ${id.value}")
-            users.remove(id.value)
+        override fun delete(id: String, version: String?, context: ScimRequestContext) {
+            if (!users.containsKey(id)) throw ResourceNotFoundException("User not found: $id")
+            users.remove(id)
         }
 
         override fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<User> =
@@ -324,19 +322,19 @@ class ScimEndpointDispatcherTest {
             override val resourceType: Class<User> = User::class.java
             override val endpoint: String = "/Users"
 
-            override fun get(id: ResourceId, context: ScimRequestContext): User =
+            override fun get(id: String, context: ScimRequestContext): User =
                 throw ResourceConflictException("User already exists")
 
             override fun create(resource: User, context: ScimRequestContext): User =
                 throw ResourceConflictException("User already exists")
 
-            override fun replace(id: ResourceId, resource: User, version: ETag?, context: ScimRequestContext): User =
+            override fun replace(id: String, resource: User, version: String?, context: ScimRequestContext): User =
                 throw ResourceConflictException("User already exists")
 
-            override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): User =
+            override fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): User =
                 throw ResourceConflictException("User already exists")
 
-            override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) =
+            override fun delete(id: String, version: String?, context: ScimRequestContext) =
                 throw ResourceConflictException("User already exists")
 
             override fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<User> =
@@ -922,11 +920,11 @@ class ScimEndpointDispatcherTest {
         val conflictHandler = object : ResourceHandler<User> {
             override val resourceType: Class<User> = User::class.java
             override val endpoint: String = "/Users"
-            override fun get(id: ResourceId, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
+            override fun get(id: String, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
             override fun create(resource: User, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
-            override fun replace(id: ResourceId, resource: User, version: ETag?, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
-            override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
-            override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) = throw ResourceConflictException("duplicate")
+            override fun replace(id: String, resource: User, version: String?, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
+            override fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): User = throw ResourceConflictException("duplicate")
+            override fun delete(id: String, version: String?, context: ScimRequestContext) = throw ResourceConflictException("duplicate")
             override fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<User> = throw ResourceConflictException("duplicate")
         }
 

--- a/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/engine/BulkEngineTest.kt
+++ b/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/engine/BulkEngineTest.kt
@@ -13,8 +13,6 @@ import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.resource.User
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
 import com.marcosbarbero.scim2.server.config.ScimServerConfig
 import com.marcosbarbero.scim2.server.port.ResourceHandler
@@ -44,8 +42,8 @@ class BulkEngineTest {
         override val resourceType: Class<User> = User::class.java
         override val endpoint: String = "/Users"
 
-        override fun get(id: ResourceId, context: ScimRequestContext): User =
-            users[id.value] ?: throw ResourceNotFoundException("User not found: ${id.value}")
+        override fun get(id: String, context: ScimRequestContext): User =
+            users[id] ?: throw ResourceNotFoundException("User not found: $id")
 
         override fun create(resource: User, context: ScimRequestContext): User {
             val id = java.util.UUID.randomUUID().toString()
@@ -54,19 +52,19 @@ class BulkEngineTest {
             return created
         }
 
-        override fun replace(id: ResourceId, resource: User, version: ETag?, context: ScimRequestContext): User {
-            val replaced = resource.copy(id = id.value)
-            users[id.value] = replaced
+        override fun replace(id: String, resource: User, version: String?, context: ScimRequestContext): User {
+            val replaced = resource.copy(id = id)
+            users[id] = replaced
             return replaced
         }
 
-        override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): User {
-            val existing = users[id.value] ?: throw ResourceNotFoundException("User not found: ${id.value}")
+        override fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): User {
+            val existing = users[id] ?: throw ResourceNotFoundException("User not found: $id")
             return existing
         }
 
-        override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) {
-            users.remove(id.value) ?: throw ResourceNotFoundException("User not found: ${id.value}")
+        override fun delete(id: String, version: String?, context: ScimRequestContext) {
+            users.remove(id) ?: throw ResourceNotFoundException("User not found: $id")
         }
 
         override fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<User> =

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/handler/DefaultResourceHandler.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/handler/DefaultResourceHandler.kt
@@ -5,8 +5,6 @@ import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.server.port.ResourceHandler
 import com.marcosbarbero.scim2.server.port.ResourceRepository
 import com.marcosbarbero.scim2.server.port.ScimRequestContext
@@ -17,28 +15,28 @@ class DefaultResourceHandler<T : ScimResource>(
     private val repository: ResourceRepository<T>
 ) : ResourceHandler<T> {
 
-    override fun get(id: ResourceId, context: ScimRequestContext): T =
+    override fun get(id: String, context: ScimRequestContext): T =
         repository.findById(id)
-            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: ${id.value}")
+            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: $id")
 
     override fun create(resource: T, context: ScimRequestContext): T =
         repository.create(resource)
 
-    override fun replace(id: ResourceId, resource: T, version: ETag?, context: ScimRequestContext): T =
+    override fun replace(id: String, resource: T, version: String?, context: ScimRequestContext): T =
         repository.replace(id, resource, version)
 
-    override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): T {
+    override fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): T {
         val existing = repository.findById(id)
-            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: ${id.value}")
+            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: $id")
         // Apply patch operations and replace
         // For now, delegate to replace with the existing resource
         // Real patch logic would apply each operation to the existing resource
         return repository.replace(id, existing, version)
     }
 
-    override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) {
+    override fun delete(id: String, version: String?, context: ScimRequestContext) {
         repository.findById(id)
-            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: ${id.value}")
+            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: $id")
         repository.delete(id, version)
     }
 

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/persistence/adapter/JpaResourceRepository.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/persistence/adapter/JpaResourceRepository.kt
@@ -9,7 +9,6 @@ import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
 import com.marcosbarbero.scim2.core.domain.model.search.SortOrder
 import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
 import com.marcosbarbero.scim2.server.port.ResourceRepository
 import com.marcosbarbero.scim2.spring.persistence.entity.ScimResourceEntity
@@ -50,17 +49,17 @@ class JpaResourceRepository<T : ScimResource>(
         return withMeta
     }
 
-    override fun findById(id: ResourceId): T? {
-        val entity = jpaRepository.findById(id.value).orElse(null) ?: return null
+    override fun findById(id: String): T? {
+        val entity = jpaRepository.findById(id).orElse(null) ?: return null
         if (entity.resourceType != resourceTypeName) return null
         return serializer.deserializeFromString(entity.resourceJson, resourceType.kotlin)
     }
 
-    override fun replace(id: ResourceId, resource: T, version: ETag?): T {
-        val entity = jpaRepository.findById(id.value).orElse(null)
-            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: ${id.value}")
+    override fun replace(id: String, resource: T, version: String?): T {
+        val entity = jpaRepository.findById(id).orElse(null)
+            ?: throw ResourceNotFoundException("${resourceType.simpleName} not found: $id")
         if (entity.resourceType != resourceTypeName) {
-            throw ResourceNotFoundException("${resourceType.simpleName} not found: ${id.value}")
+            throw ResourceNotFoundException("${resourceType.simpleName} not found: $id")
         }
         val now = Instant.now()
         val newVersion = entity.version + 1
@@ -70,7 +69,7 @@ class JpaResourceRepository<T : ScimResource>(
             lastModified = now,
             version = ETag("W/\"$newVersion\"")
         )
-        val withMeta = copyWithIdAndMeta(resource, id.value, meta)
+        val withMeta = copyWithIdAndMeta(resource, id, meta)
         entity.resourceJson = serializer.serializeToString(withMeta)
         entity.externalId = resource.externalId
         entity.displayName = extractDisplayName(resource)
@@ -80,10 +79,10 @@ class JpaResourceRepository<T : ScimResource>(
         return withMeta
     }
 
-    override fun delete(id: ResourceId, version: ETag?) {
-        val deleted = jpaRepository.deleteByIdAndResourceType(id.value, resourceTypeName)
+    override fun delete(id: String, version: String?) {
+        val deleted = jpaRepository.deleteByIdAndResourceType(id, resourceTypeName)
         if (deleted == 0L) {
-            throw ResourceNotFoundException("${resourceType.simpleName} not found: ${id.value}")
+            throw ResourceNotFoundException("${resourceType.simpleName} not found: $id")
         }
     }
 

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolver.kt
@@ -19,20 +19,15 @@ open class JwtIdentityResolver(
 
     override fun resolve(request: ScimHttpRequest): ScimRequestContext {
         val authentication = SecurityContextHolder.getContext().authentication
-        val jwt = when (authentication) {
-            is JwtAuthenticationToken -> authentication.token
-            else -> null
-        }
+        val jwt = (authentication as? JwtAuthenticationToken)?.token
 
-        return if (jwt != null) {
+        return jwt?.let {
             ScimRequestContext(
-                principalId = extractPrincipal(jwt),
-                roles = extractRoles(jwt),
-                attributes = extractAttributes(jwt)
+                principalId = extractPrincipal(it),
+                roles = extractRoles(it),
+                attributes = extractAttributes(it)
             )
-        } else {
-            ScimRequestContext()
-        }
+        } ?: ScimRequestContext()
     }
 
     protected open fun extractPrincipal(jwt: Jwt): String =

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/KeycloakIdentityResolver.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/security/KeycloakIdentityResolver.kt
@@ -20,9 +20,9 @@ class KeycloakIdentityResolver(
         val realmAccess = jwt.getClaim<Map<String, Any>>(claims.realmAccess)
         (realmAccess?.get("roles") as? List<String>)?.let { roles.addAll(it) }
         // Client roles
-        if (clientId != null) {
+        clientId?.let { cid ->
             val resourceAccess = jwt.getClaim<Map<String, Any>>(claims.resourceAccess)
-            val clientAccess = resourceAccess?.get(clientId) as? Map<String, Any>
+            val clientAccess = resourceAccess?.get(cid) as? Map<String, Any>
             (clientAccess?.get("roles") as? List<String>)?.let { roles.addAll(it) }
         }
         return roles

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimServerAutoConfigurationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimServerAutoConfigurationTest.kt
@@ -4,8 +4,6 @@ import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
 import com.marcosbarbero.scim2.core.domain.model.resource.User
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.core.schema.introspector.SchemaRegistry
 import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
 import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
@@ -119,17 +117,17 @@ class ScimServerAutoConfigurationTest {
     fun `DefaultResourceHandler delegates to repository`() {
         val users = mutableMapOf<String, User>()
         val repo = object : ResourceRepository<User> {
-            override fun findById(id: ResourceId): User? = users[id.value]
+            override fun findById(id: String): User? = users[id]
             override fun create(resource: User): User {
                 val created = resource.copy(id = "generated-id")
                 users["generated-id"] = created
                 return created
             }
-            override fun replace(id: ResourceId, resource: User, version: ETag?): User {
-                users[id.value] = resource
+            override fun replace(id: String, resource: User, version: String?): User {
+                users[id] = resource
                 return resource
             }
-            override fun delete(id: ResourceId, version: ETag?) { users.remove(id.value) }
+            override fun delete(id: String, version: String?) { users.remove(id) }
             override fun search(request: SearchRequest): ListResponse<User> =
                 ListResponse(totalResults = users.size, resources = users.values.toList())
         }
@@ -140,23 +138,23 @@ class ScimServerAutoConfigurationTest {
         val created = handler.create(User(userName = "testuser"), context)
         created.id shouldBe "generated-id"
 
-        val found = handler.get(ResourceId("generated-id"), context)
+        val found = handler.get("generated-id", context)
         found.userName shouldBe "testuser"
 
         val searchResult = handler.search(SearchRequest(), context)
         searchResult.totalResults shouldBe 1
 
-        handler.delete(ResourceId("generated-id"), null, context)
+        handler.delete("generated-id", null, context)
         handler.search(SearchRequest(), context).totalResults shouldBe 0
     }
 
     @Test
     fun `auto-registers scimUserHandler when UserRepository is present`() {
         val repo = object : ResourceRepository<User> {
-            override fun findById(id: ResourceId): User? = null
+            override fun findById(id: String): User? = null
             override fun create(resource: User): User = resource
-            override fun replace(id: ResourceId, resource: User, version: ETag?): User = resource
-            override fun delete(id: ResourceId, version: ETag?) {}
+            override fun replace(id: String, resource: User, version: String?): User = resource
+            override fun delete(id: String, version: String?) {}
             override fun search(request: SearchRequest): ListResponse<User> =
                 ListResponse(totalResults = 0, resources = emptyList())
         }
@@ -193,11 +191,11 @@ class ScimServerAutoConfigurationTest {
     private class TestUserHandler : ResourceHandler<User> {
         override val resourceType: Class<User> = User::class.java
         override val endpoint: String = "/Users"
-        override fun get(id: ResourceId, context: ScimRequestContext): User = throw UnsupportedOperationException()
+        override fun get(id: String, context: ScimRequestContext): User = throw UnsupportedOperationException()
         override fun create(resource: User, context: ScimRequestContext): User = throw UnsupportedOperationException()
-        override fun replace(id: ResourceId, resource: User, version: ETag?, context: ScimRequestContext): User = throw UnsupportedOperationException()
-        override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): User = throw UnsupportedOperationException()
-        override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) = throw UnsupportedOperationException()
+        override fun replace(id: String, resource: User, version: String?, context: ScimRequestContext): User = throw UnsupportedOperationException()
+        override fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): User = throw UnsupportedOperationException()
+        override fun delete(id: String, version: String?, context: ScimRequestContext) = throw UnsupportedOperationException()
         override fun search(request: SearchRequest, context: ScimRequestContext): ListResponse<User> = throw UnsupportedOperationException()
     }
 }

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/JpaResourceRepositoryTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/JpaResourceRepositoryTest.kt
@@ -4,7 +4,6 @@ import com.marcosbarbero.scim2.core.domain.model.error.ResourceNotFoundException
 import com.marcosbarbero.scim2.core.domain.model.resource.Group
 import com.marcosbarbero.scim2.core.domain.model.resource.User
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
 import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
 import com.marcosbarbero.scim2.spring.persistence.adapter.JpaResourceRepository
@@ -69,7 +68,7 @@ class JpaResourceRepositoryTest {
         val user = User(userName = faker.name.firstName())
         val created = userRepository.create(user)
 
-        val found = userRepository.findById(ResourceId(created.id!!))
+        val found = userRepository.findById(created.id!!)
 
         found.shouldNotBeNull()
         found.id shouldBe created.id
@@ -78,7 +77,7 @@ class JpaResourceRepositoryTest {
 
     @Test
     fun `findById returns null for non-existent resource`() {
-        val result = userRepository.findById(ResourceId("non-existent"))
+        val result = userRepository.findById("non-existent")
         result.shouldBeNull()
     }
 
@@ -87,7 +86,7 @@ class JpaResourceRepositoryTest {
         val group = Group(displayName = faker.name.name())
         val created = groupRepository.create(group)
 
-        val result = userRepository.findById(ResourceId(created.id!!))
+        val result = userRepository.findById(created.id!!)
         result.shouldBeNull()
     }
 
@@ -97,7 +96,7 @@ class JpaResourceRepositoryTest {
         val created = userRepository.create(user)
 
         val updated = userRepository.replace(
-            ResourceId(created.id!!),
+            created.id!!,
             User(userName = created.userName, displayName = "Updated"),
             null
         )
@@ -106,7 +105,7 @@ class JpaResourceRepositoryTest {
         updated.meta!!.version!!.value shouldBe "W/\"2\""
         updated.meta!!.created shouldBe created.meta!!.created
 
-        val found = userRepository.findById(ResourceId(created.id!!))
+        val found = userRepository.findById(created.id!!)
         found.shouldNotBeNull()
         found.displayName shouldBe "Updated"
     }
@@ -115,7 +114,7 @@ class JpaResourceRepositoryTest {
     fun `replace throws ResourceNotFoundException for non-existent resource`() {
         assertThrows<ResourceNotFoundException> {
             userRepository.replace(
-                ResourceId("non-existent"),
+                "non-existent",
                 User(userName = "test"),
                 null
             )
@@ -127,15 +126,15 @@ class JpaResourceRepositoryTest {
         val user = User(userName = faker.name.firstName())
         val created = userRepository.create(user)
 
-        userRepository.delete(ResourceId(created.id!!), null)
+        userRepository.delete(created.id!!, null)
 
-        userRepository.findById(ResourceId(created.id!!)).shouldBeNull()
+        userRepository.findById(created.id!!).shouldBeNull()
     }
 
     @Test
     fun `delete throws ResourceNotFoundException for non-existent resource`() {
         assertThrows<ResourceNotFoundException> {
-            userRepository.delete(ResourceId("non-existent"), null)
+            userRepository.delete("non-existent", null)
         }
     }
 

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/ScimPersistenceAutoConfigurationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/ScimPersistenceAutoConfigurationTest.kt
@@ -3,8 +3,6 @@ package com.marcosbarbero.scim2.spring.persistence
 import com.marcosbarbero.scim2.core.domain.model.resource.User
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.server.port.ResourceRepository
 import com.marcosbarbero.scim2.spring.autoconfigure.ScimJacksonAutoConfiguration
 import com.marcosbarbero.scim2.spring.autoconfigure.ScimPersistenceAutoConfiguration
@@ -60,10 +58,10 @@ class ScimPersistenceAutoConfigurationTest {
     @Test
     fun `backs off when custom user repository provided`() {
         val customRepo = object : ResourceRepository<User> {
-            override fun findById(id: ResourceId): User? = null
+            override fun findById(id: String): User? = null
             override fun create(resource: User): User = resource
-            override fun replace(id: ResourceId, resource: User, version: ETag?): User = resource
-            override fun delete(id: ResourceId, version: ETag?) {}
+            override fun replace(id: String, resource: User, version: String?): User = resource
+            override fun delete(id: String, version: String?) {}
             override fun search(request: SearchRequest): ListResponse<User> =
                 ListResponse(totalResults = 0, resources = emptyList())
         }

--- a/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/contract/ResourceHandlerContractTest.kt
+++ b/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/contract/ResourceHandlerContractTest.kt
@@ -3,7 +3,6 @@ package com.marcosbarbero.scim2.test.contract
 import com.marcosbarbero.scim2.core.domain.model.error.ResourceNotFoundException
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.server.port.ResourceHandler
 import com.marcosbarbero.scim2.server.port.ScimRequestContext
 import io.kotest.assertions.throwables.shouldThrow
@@ -64,14 +63,14 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     @Test
     fun `get returns created resource`() {
         val created = handler.create(sampleResource(), context)
-        val retrieved = handler.get(ResourceId(created.id!!), context)
+        val retrieved = handler.get(created.id!!, context)
         retrieved.id shouldBe created.id
     }
 
     @Test
     fun `get non-existent throws ResourceNotFoundException`() {
         shouldThrow<ResourceNotFoundException> {
-            handler.get(ResourceId("non-existent-id"), context)
+            handler.get("non-existent-id", context)
         }
     }
 
@@ -79,7 +78,7 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     fun `replace updates resource`() {
         val created = handler.create(sampleResource(), context)
         val modified = modifiedResource(created)
-        val replaced = handler.replace(ResourceId(created.id!!), modified, null, context)
+        val replaced = handler.replace(created.id!!, modified, null, context)
         replaced.id shouldBe created.id
         replaced.meta.shouldNotBeNull()
         replaced.meta!!.lastModified.shouldNotBeNull()
@@ -88,7 +87,7 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     @Test
     fun `replace non-existent throws ResourceNotFoundException`() {
         shouldThrow<ResourceNotFoundException> {
-            handler.replace(ResourceId("non-existent-id"), sampleResource(), null, context)
+            handler.replace("non-existent-id", sampleResource(), null, context)
         }
     }
 
@@ -96,7 +95,7 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     fun `replace preserves created timestamp`() {
         val created = handler.create(sampleResource(), context)
         val modified = modifiedResource(created)
-        val replaced = handler.replace(ResourceId(created.id!!), modified, null, context)
+        val replaced = handler.replace(created.id!!, modified, null, context)
         replaced.meta!!.created shouldBe created.meta!!.created
     }
 
@@ -104,7 +103,7 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     fun `replace updates lastModified timestamp`() {
         val created = handler.create(sampleResource(), context)
         val modified = modifiedResource(created)
-        val replaced = handler.replace(ResourceId(created.id!!), modified, null, context)
+        val replaced = handler.replace(created.id!!, modified, null, context)
         replaced.meta!!.lastModified shouldNotBe null
     }
 
@@ -112,23 +111,23 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     fun `replace updates version`() {
         val created = handler.create(sampleResource(), context)
         val modified = modifiedResource(created)
-        val replaced = handler.replace(ResourceId(created.id!!), modified, null, context)
+        val replaced = handler.replace(created.id!!, modified, null, context)
         replaced.meta!!.version shouldNotBe created.meta!!.version
     }
 
     @Test
     fun `delete removes resource`() {
         val created = handler.create(sampleResource(), context)
-        handler.delete(ResourceId(created.id!!), null, context)
+        handler.delete(created.id!!, null, context)
         shouldThrow<ResourceNotFoundException> {
-            handler.get(ResourceId(created.id!!), context)
+            handler.get(created.id!!, context)
         }
     }
 
     @Test
     fun `delete non-existent throws ResourceNotFoundException`() {
         shouldThrow<ResourceNotFoundException> {
-            handler.delete(ResourceId("non-existent-id"), null, context)
+            handler.delete("non-existent-id", null, context)
         }
     }
 
@@ -183,7 +182,7 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     @Test
     fun `create then get returns same id`() {
         val created = handler.create(sampleResource(), context)
-        val retrieved = handler.get(ResourceId(created.id!!), context)
+        val retrieved = handler.get(created.id!!, context)
         retrieved.id shouldBe created.id
     }
 
@@ -197,7 +196,7 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     @Test
     fun `delete then create allows reuse of search`() {
         val created = handler.create(sampleResource(), context)
-        handler.delete(ResourceId(created.id!!), null, context)
+        handler.delete(created.id!!, null, context)
         val result = handler.search(SearchRequest(), context)
         result.totalResults shouldBe 0
     }
@@ -206,8 +205,8 @@ abstract class ResourceHandlerContractTest<T : ScimResource> {
     fun `replace then get returns updated resource`() {
         val created = handler.create(sampleResource(), context)
         val modified = modifiedResource(created)
-        handler.replace(ResourceId(created.id!!), modified, null, context)
-        val retrieved = handler.get(ResourceId(created.id!!), context)
+        handler.replace(created.id!!, modified, null, context)
+        val retrieved = handler.get(created.id!!, context)
         retrieved.id shouldBe created.id
     }
 

--- a/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/handler/InMemoryResourceHandler.kt
+++ b/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/handler/InMemoryResourceHandler.kt
@@ -1,13 +1,10 @@
 package com.marcosbarbero.scim2.test.handler
 
 import com.marcosbarbero.scim2.core.domain.model.error.ResourceNotFoundException
-import com.marcosbarbero.scim2.core.domain.model.patch.PatchOp
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
-import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.server.port.ResourceHandler
 import com.marcosbarbero.scim2.server.port.ScimRequestContext
 import com.marcosbarbero.scim2.test.repository.InMemoryResourceRepository
@@ -19,34 +16,30 @@ class InMemoryResourceHandler<T : ScimResource>(
     private val patchApplier: ((T, PatchRequest) -> T)? = null
 ) : ResourceHandler<T> {
 
-    override fun get(id: ResourceId, context: ScimRequestContext): T {
+    override fun get(id: String, context: ScimRequestContext): T {
         return repository.findById(id)
-            ?: throw ResourceNotFoundException("Resource not found: ${id.value}")
+            ?: throw ResourceNotFoundException("Resource not found: $id")
     }
 
     override fun create(resource: T, context: ScimRequestContext): T {
         return repository.create(resource)
     }
 
-    override fun replace(id: ResourceId, resource: T, version: ETag?, context: ScimRequestContext): T {
+    override fun replace(id: String, resource: T, version: String?, context: ScimRequestContext): T {
         return repository.replace(id, resource, version)
     }
 
-    override fun patch(id: ResourceId, request: PatchRequest, version: ETag?, context: ScimRequestContext): T {
+    override fun patch(id: String, request: PatchRequest, version: String?, context: ScimRequestContext): T {
         val existing = repository.findById(id)
-            ?: throw ResourceNotFoundException("Resource not found: ${id.value}")
+            ?: throw ResourceNotFoundException("Resource not found: $id")
 
-        val patched = if (patchApplier != null) {
-            patchApplier.invoke(existing, request)
-        } else {
-            // Default no-op: return existing resource unchanged for operations we cannot apply generically
-            existing
-        }
+        val patched = patchApplier?.invoke(existing, request)
+            ?: existing // Default no-op: return existing resource unchanged for operations we cannot apply generically
 
         return repository.replace(id, patched, version)
     }
 
-    override fun delete(id: ResourceId, version: ETag?, context: ScimRequestContext) {
+    override fun delete(id: String, version: String?, context: ScimRequestContext) {
         repository.delete(id, version)
     }
 

--- a/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/repository/InMemoryResourceRepository.kt
+++ b/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/repository/InMemoryResourceRepository.kt
@@ -5,7 +5,6 @@ import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
 import com.marcosbarbero.scim2.core.domain.vo.ETag
-import com.marcosbarbero.scim2.core.domain.vo.ResourceId
 import com.marcosbarbero.scim2.core.domain.model.error.ResourceNotFoundException
 import com.marcosbarbero.scim2.core.domain.model.error.ResourceConflictException
 import com.marcosbarbero.scim2.server.port.ResourceRepository
@@ -19,7 +18,7 @@ class InMemoryResourceRepository<T : ScimResource>(
 
     private val store = ConcurrentHashMap<String, T>()
 
-    override fun findById(id: ResourceId): T? = store[id.value]
+    override fun findById(id: String): T? = store[id]
 
     override fun create(resource: T): T {
         val id = resource.id ?: UUID.randomUUID().toString()
@@ -38,10 +37,10 @@ class InMemoryResourceRepository<T : ScimResource>(
         return stored
     }
 
-    override fun replace(id: ResourceId, resource: T, version: ETag?): T {
-        val existing = store[id.value]
-            ?: throw ResourceNotFoundException("Resource not found: ${id.value}")
-        if (version != null && existing.meta?.version != null && existing.meta?.version != version) {
+    override fun replace(id: String, resource: T, version: String?): T {
+        val existing = store[id]
+            ?: throw ResourceNotFoundException("Resource not found: $id")
+        if (version != null && existing.meta?.version != null && existing.meta?.version?.value != version) {
             throw ResourceConflictException("ETag mismatch")
         }
         val now = Instant.now()
@@ -51,18 +50,18 @@ class InMemoryResourceRepository<T : ScimResource>(
             lastModified = now,
             version = ETag("W/\"${UUID.randomUUID()}\"")
         )
-        val stored = copyWithIdAndMeta(resource, id.value, meta)
-        store[id.value] = stored
+        val stored = copyWithIdAndMeta(resource, id, meta)
+        store[id] = stored
         return stored
     }
 
-    override fun delete(id: ResourceId, version: ETag?) {
-        val existing = store[id.value]
-            ?: throw ResourceNotFoundException("Resource not found: ${id.value}")
-        if (version != null && existing.meta?.version != null && existing.meta?.version != version) {
+    override fun delete(id: String, version: String?) {
+        val existing = store[id]
+            ?: throw ResourceNotFoundException("Resource not found: $id")
+        if (version != null && existing.meta?.version != null && existing.meta?.version?.value != version) {
             throw ResourceConflictException("ETag mismatch")
         }
-        store.remove(id.value)
+        store.remove(id)
     }
 
     override fun search(request: SearchRequest): ListResponse<T> {


### PR DESCRIPTION
## Summary
- Replace Java-like null checks (`if (x != null)` / `if (x == null)`) with idiomatic Kotlin (`?.let`, `?:`, `?.run`) across 12 source files in core, server, client, test, and autoconfigure modules
- Change `ResourceHandler`, `ResourceRepository`, and `MeHandler` SPI interfaces to use `String` parameters instead of `@JvmInline value class` types (`ResourceId`, `ETag`) -- this eliminates JVM name-mangling issues when implementing these interfaces from Java
- Add namastack-outbox adapter code example to `docs/outbox-pattern.md` and create ADR-0023 documenting the integration strategy

## Test plan
- [x] `mvn clean verify -B` passes (all modules compile, all tests green)
- [ ] Review idiomatic Kotlin changes preserve identical behavior
- [ ] Verify Java sample server still compiles and tests pass with new SPI signatures
- [ ] Review outbox adapter code example for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)