### PR TITLE
docs: Comprehensive documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,16 +198,17 @@ ScimClients.getGroup(client, id);
 
 ## Modules
 
-| Module | Description |
-|---|---|
-| `scim2-sdk-core` | Domain model, filter/path parsing, PATCH engine, serialization SPI |
-| `scim2-sdk-server` | Server framework with hexagonal architecture (ports + adapters) |
-| `scim2-sdk-client` | Fluent client API with Kotlin DSLs |
-| `scim2-sdk-client-httpclient` | Java HttpClient transport adapter |
-| `scim2-sdk-client-okhttp` | OkHttp transport adapter |
-| `scim2-sdk-spring-boot-autoconfigure` | Spring Boot auto-configuration |
-| `scim2-sdk-spring-boot-starter` | Spring Boot starter (aggregates dependencies) |
-| `scim2-sdk-test` | Test fixtures, contract tests, in-memory server |
+| Module | Description | Details |
+|---|---|---|
+| [`scim2-sdk-core`](scim2-sdk-core/) | Domain model, filter/path parsing, PATCH engine, serialization SPI | [README](scim2-sdk-core/README.md) |
+| [`scim2-sdk-server`](scim2-sdk-server/) | SCIM Service Provider framework (ports + adapters) | [README](scim2-sdk-server/README.md) |
+| [`scim2-sdk-client`](scim2-sdk-client/) | Fluent client API with Kotlin DSLs | [README](scim2-sdk-client/README.md) |
+| [`scim2-sdk-client-httpclient`](scim2-sdk-client-httpclient/) | Java HttpClient transport adapter | [README](scim2-sdk-client-httpclient/README.md) |
+| [`scim2-sdk-client-okhttp`](scim2-sdk-client-okhttp/) | OkHttp transport adapter | [README](scim2-sdk-client-okhttp/README.md) |
+| [`scim2-sdk-spring-boot-autoconfigure`](scim2-sdk-spring-boot-autoconfigure/) | Spring Boot auto-configuration | [README](scim2-sdk-spring-boot-autoconfigure/README.md) |
+| [`scim2-sdk-spring-boot-starter`](scim2-sdk-spring-boot-starter/) | Spring Boot starter (aggregates dependencies) | [README](scim2-sdk-spring-boot-starter/README.md) |
+| [`scim2-sdk-test`](scim2-sdk-test/) | Test fixtures, contract tests, in-memory server | [README](scim2-sdk-test/README.md) |
+| [`scim2-sdk-bom`](scim2-sdk-bom/) | Bill of Materials for version management | [README](scim2-sdk-bom/README.md) |
 
 ## Configuration Properties
 
@@ -230,10 +231,31 @@ All properties are optional with sensible defaults:
 
 ## Database Support
 
-When `scim.persistence.enabled=true`, the JPA adapter stores resources as JSON. Reference schemas are provided for:
-- PostgreSQL, MySQL, Oracle, MS SQL Server, H2
+When `scim.persistence.enabled=true`, the JPA adapter stores SCIM resources as JSON in a single table:
 
-Find them in `scim2-sdk-spring-boot-autoconfigure/src/main/resources/db/scim/`.
+```sql
+CREATE TABLE scim_resources (
+    id              VARCHAR(255) NOT NULL PRIMARY KEY,
+    resource_type   VARCHAR(100) NOT NULL,    -- "User", "Group", etc.
+    external_id     VARCHAR(255),
+    display_name    VARCHAR(500),
+    resource_json   TEXT NOT NULL,             -- Full SCIM resource as JSON
+    version         BIGINT NOT NULL DEFAULT 1, -- ETag version
+    created         TIMESTAMP NOT NULL,
+    last_modified   TIMESTAMP NOT NULL
+);
+```
+
+This design stores any SCIM resource type in one table, discriminated by `resource_type`. The full resource is preserved as JSON in `resource_json`, enabling schema-less flexibility while maintaining queryable metadata columns.
+
+Reference schemas for specific databases:
+- [PostgreSQL](scim2-sdk-spring-boot-autoconfigure/src/main/resources/db/scim/schema-postgresql.sql)
+- [MySQL](scim2-sdk-spring-boot-autoconfigure/src/main/resources/db/scim/schema-mysql.sql)
+- [Oracle](scim2-sdk-spring-boot-autoconfigure/src/main/resources/db/scim/schema-oracle.sql)
+- [MS SQL Server](scim2-sdk-spring-boot-autoconfigure/src/main/resources/db/scim/schema-mssql.sql)
+- [H2 (testing)](scim2-sdk-spring-boot-autoconfigure/src/main/resources/db/scim/schema-h2.sql)
+
+Opt-in auto-migration via Flyway: set `scim.persistence.auto-migrate=true`.
 
 ### Database Migration
 

--- a/scim2-sdk-client-httpclient/README.md
+++ b/scim2-sdk-client-httpclient/README.md
@@ -3,6 +3,8 @@
 `HttpTransport` adapter using Java's built-in `java.net.http.HttpClient` (Java 11+). This is the default transport -- zero additional dependencies.
 
 ## Usage
+
+### Kotlin
 ```kotlin
 val transport = JavaHttpClientTransport()
 // or with custom HttpClient:
@@ -16,4 +18,20 @@ val client = ScimClientBuilder()
     .transport(transport)
     // ...
     .build()
+```
+
+### Java
+```java
+var transport = new JavaHttpClientTransport();
+// or with custom HttpClient:
+var transport = new JavaHttpClientTransport(
+    HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .build()
+);
+
+ScimClient client = new ScimClientBuilder()
+    .transport(transport)
+    // ...
+    .build();
 ```

--- a/scim2-sdk-client-okhttp/README.md
+++ b/scim2-sdk-client-okhttp/README.md
@@ -3,6 +3,8 @@
 `HttpTransport` adapter using [OkHttp](https://square.github.io/okhttp/). Use this when you need OkHttp features like connection pooling, interceptors, or WebSocket support.
 
 ## Usage
+
+### Kotlin
 ```kotlin
 val transport = OkHttpTransport()
 // or with custom OkHttpClient:
@@ -17,6 +19,23 @@ val client = ScimClientBuilder()
     .transport(transport)
     // ...
     .build()
+```
+
+### Java
+```java
+var transport = new OkHttpTransport();
+// or with custom OkHttpClient:
+var transport = new OkHttpTransport(
+    new OkHttpClient.Builder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .addInterceptor(loggingInterceptor)
+        .build()
+);
+
+ScimClient client = new ScimClientBuilder()
+    .transport(transport)
+    // ...
+    .build();
 ```
 
 ## Dependencies

--- a/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClientTest.kt
+++ b/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/DefaultScimClientTest.kt
@@ -84,7 +84,8 @@ class DefaultScimClientTest {
     @Test
     fun `get sends GET request and returns 200 with resource`() {
         val userId = faker.random.randomString(10)
-        val user = User(id = userId, userName = "john")
+        val userName = faker.name.firstName().lowercase()
+        val user = User(id = userId, userName = userName)
         val responseBody = """{"id":"$userId"}""".toByteArray()
 
         every { serializer.deserialize(responseBody, User::class) } returns user
@@ -164,9 +165,10 @@ class DefaultScimClientTest {
 
     @Test
     fun `search sends POST to search endpoint`() {
-        val searchRequest = SearchRequest(filter = "userName eq \"john\"", startIndex = 1, count = 10)
-        val listResponse = ListResponse<User>(totalResults = 1, resources = listOf(User(userName = "john")))
-        val serializedBody = """{"filter":"userName eq \"john\""}""".toByteArray()
+        val searchUserName = faker.name.firstName().lowercase()
+        val searchRequest = SearchRequest(filter = "userName eq \"$searchUserName\"", startIndex = 1, count = 10)
+        val listResponse = ListResponse<User>(totalResults = 1, resources = listOf(User(userName = searchUserName)))
+        val serializedBody = """{"filter":"userName eq \"$searchUserName\""}""".toByteArray()
         val responseBody = """{"totalResults":1}""".toByteArray()
 
         every { serializer.serialize(searchRequest) } returns serializedBody

--- a/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/ScimClientExtensionsTest.kt
+++ b/scim2-sdk-client/src/test/kotlin/com/marcosbarbero/scim2/client/api/ScimClientExtensionsTest.kt
@@ -6,6 +6,7 @@ import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
 import com.marcosbarbero.scim2.core.domain.model.resource.User
 import com.marcosbarbero.scim2.core.domain.model.search.ListResponse
 import com.marcosbarbero.scim2.core.domain.model.search.SearchRequest
+import io.github.serpro69.kfaker.Faker
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -19,14 +20,20 @@ import kotlin.reflect.KClass
 
 class ScimClientExtensionsTest {
 
+    private val faker = Faker()
     private lateinit var client: ScimClient
 
+    private val userId = java.util.UUID.randomUUID().toString()
+    private val groupId = java.util.UUID.randomUUID().toString()
+    private val userName = "john_${System.nanoTime()}"
+    private val groupName = "admins_${System.nanoTime()}"
+
     private val userResponse = ScimResponse(
-        value = User(id = "u1", userName = "john"),
+        value = User(id = userId, userName = userName),
         statusCode = 200
     )
     private val groupResponse = ScimResponse(
-        value = Group(id = "g1", displayName = "admins"),
+        value = Group(id = groupId, displayName = groupName),
         statusCode = 200
     )
 
@@ -39,8 +46,8 @@ class ScimClientExtensionsTest {
 
     @Test
     fun `createUser calls create with Users endpoint and User class`() {
-        val user = User(userName = "john")
-        val expected = ScimResponse(value = User(id = "u1", userName = "john"), statusCode = 201)
+        val user = User(userName = userName)
+        val expected = ScimResponse(value = User(id = userId, userName = userName), statusCode = 201)
         every { client.create("/Users", user, User::class) } returns expected
 
         val result = client.createUser(user)
@@ -51,39 +58,40 @@ class ScimClientExtensionsTest {
 
     @Test
     fun `getUser calls get with Users endpoint and User class`() {
-        every { client.get("/Users", "u1", User::class) } returns userResponse
+        every { client.get("/Users", userId, User::class) } returns userResponse
 
-        val result = client.getUser("u1")
+        val result = client.getUser(userId)
 
         result shouldBe userResponse
-        verify { client.get("/Users", "u1", User::class) }
+        verify { client.get("/Users", userId, User::class) }
     }
 
     @Test
     fun `replaceUser calls replace with Users endpoint and User class`() {
-        val user = User(id = "u1", userName = "updated")
-        every { client.replace("/Users", "u1", user, User::class) } returns userResponse
+        val updatedName = faker.name.firstName().lowercase()
+        val user = User(id = userId, userName = updatedName)
+        every { client.replace("/Users", userId, user, User::class) } returns userResponse
 
-        client.replaceUser("u1", user)
+        client.replaceUser(userId, user)
 
-        verify { client.replace("/Users", "u1", user, User::class) }
+        verify { client.replace("/Users", userId, user, User::class) }
     }
 
     @Test
     fun `patchUser calls patch with Users endpoint and User class`() {
         val patch = PatchRequest()
-        every { client.patch("/Users", "u1", patch, User::class) } returns userResponse
+        every { client.patch("/Users", userId, patch, User::class) } returns userResponse
 
-        client.patchUser("u1", patch)
+        client.patchUser(userId, patch)
 
-        verify { client.patch("/Users", "u1", patch, User::class) }
+        verify { client.patch("/Users", userId, patch, User::class) }
     }
 
     @Test
     fun `deleteUser calls delete with Users endpoint`() {
-        client.deleteUser("u1")
+        client.deleteUser(userId)
 
-        verify { client.delete("/Users", "u1") }
+        verify { client.delete("/Users", userId) }
     }
 
     @Test
@@ -101,24 +109,25 @@ class ScimClientExtensionsTest {
 
     @Test
     fun `searchUsers with filter string builds SearchRequest`() {
+        val searchName = faker.name.firstName().lowercase()
         val listResponse = ScimResponse(
-            value = ListResponse<User>(totalResults = 1, resources = listOf(User(userName = "john"))),
+            value = ListResponse<User>(totalResults = 1, resources = listOf(User(userName = searchName))),
             statusCode = 200
         )
         val requestSlot = slot<SearchRequest>()
         every { client.search("/Users", capture(requestSlot), User::class) } returns listResponse
 
-        client.searchUsers("userName sw \"john\"")
+        client.searchUsers("userName sw \"$searchName\"")
 
-        requestSlot.captured.filter shouldBe "userName sw \"john\""
+        requestSlot.captured.filter shouldBe "userName sw \"$searchName\""
     }
 
     // ===== Group Operations =====
 
     @Test
     fun `createGroup calls create with Groups endpoint and Group class`() {
-        val group = Group(displayName = "admins")
-        val expected = ScimResponse(value = Group(id = "g1", displayName = "admins"), statusCode = 201)
+        val group = Group(displayName = groupName)
+        val expected = ScimResponse(value = Group(id = groupId, displayName = groupName), statusCode = 201)
         every { client.create("/Groups", group, Group::class) } returns expected
 
         val result = client.createGroup(group)
@@ -129,39 +138,40 @@ class ScimClientExtensionsTest {
 
     @Test
     fun `getGroup calls get with Groups endpoint and Group class`() {
-        every { client.get("/Groups", "g1", Group::class) } returns groupResponse
+        every { client.get("/Groups", groupId, Group::class) } returns groupResponse
 
-        val result = client.getGroup("g1")
+        val result = client.getGroup(groupId)
 
         result shouldBe groupResponse
-        verify { client.get("/Groups", "g1", Group::class) }
+        verify { client.get("/Groups", groupId, Group::class) }
     }
 
     @Test
     fun `replaceGroup calls replace with Groups endpoint and Group class`() {
-        val group = Group(id = "g1", displayName = "updated")
-        every { client.replace("/Groups", "g1", group, Group::class) } returns groupResponse
+        val updatedGroupName = faker.name.name()
+        val group = Group(id = groupId, displayName = updatedGroupName)
+        every { client.replace("/Groups", groupId, group, Group::class) } returns groupResponse
 
-        client.replaceGroup("g1", group)
+        client.replaceGroup(groupId, group)
 
-        verify { client.replace("/Groups", "g1", group, Group::class) }
+        verify { client.replace("/Groups", groupId, group, Group::class) }
     }
 
     @Test
     fun `patchGroup calls patch with Groups endpoint and Group class`() {
         val patch = PatchRequest()
-        every { client.patch("/Groups", "g1", patch, Group::class) } returns groupResponse
+        every { client.patch("/Groups", groupId, patch, Group::class) } returns groupResponse
 
-        client.patchGroup("g1", patch)
+        client.patchGroup(groupId, patch)
 
-        verify { client.patch("/Groups", "g1", patch, Group::class) }
+        verify { client.patch("/Groups", groupId, patch, Group::class) }
     }
 
     @Test
     fun `deleteGroup calls delete with Groups endpoint`() {
-        client.deleteGroup("g1")
+        client.deleteGroup(groupId)
 
-        verify { client.delete("/Groups", "g1") }
+        verify { client.delete("/Groups", groupId) }
     }
 
     @Test
@@ -181,8 +191,8 @@ class ScimClientExtensionsTest {
 
     @Test
     fun `createResource reads ScimResource annotation for User`() {
-        val user = User(userName = "john")
-        val expected = ScimResponse(value = User(id = "u1", userName = "john"), statusCode = 201)
+        val user = User(userName = userName)
+        val expected = ScimResponse(value = User(id = userId, userName = userName), statusCode = 201)
         every { client.create("/Users", user, User::class) } returns expected
 
         val result = client.createResource(user)
@@ -193,8 +203,8 @@ class ScimClientExtensionsTest {
 
     @Test
     fun `createResource reads ScimResource annotation for Group`() {
-        val group = Group(displayName = "admins")
-        val expected = ScimResponse(value = Group(id = "g1", displayName = "admins"), statusCode = 201)
+        val group = Group(displayName = groupName)
+        val expected = ScimResponse(value = Group(id = groupId, displayName = groupName), statusCode = 201)
         every { client.create("/Groups", group, Group::class) } returns expected
 
         val result = client.createResource(group)
@@ -216,12 +226,12 @@ class ScimClientExtensionsTest {
 
     @Test
     fun `getResource reads ScimResource annotation`() {
-        every { client.get("/Users", "u1", User::class) } returns userResponse
+        every { client.get("/Users", userId, User::class) } returns userResponse
 
-        val result = client.getResource<User>("u1")
+        val result = client.getResource<User>(userId)
 
         result shouldBe userResponse
-        verify { client.get("/Users", "u1", User::class) }
+        verify { client.get("/Users", userId, User::class) }
     }
 
     @Test

--- a/scim2-sdk-core/README.md
+++ b/scim2-sdk-core/README.md
@@ -19,24 +19,49 @@ Pre-built Kotlin data classes for all SCIM 2.0 resource types:
 
 ### Filter Parser
 A complete recursive-descent parser for SCIM filter expressions:
+
+#### Kotlin
 ```kotlin
 val filter = FilterParser.parse("userName eq \"john\" and active eq true")
 // Produces an AST: LogicalExpression(AND, AttributeExpression(...), AttributeExpression(...))
 ```
+
+#### Java
+```java
+var filter = FilterParser.parse("userName eq \"john\" and active eq true");
+// Produces an AST: LogicalExpression(AND, AttributeExpression(...), AttributeExpression(...))
+```
+
 Includes `FilterVisitor<T>` for transforming filters (to SQL, to predicates, to string, etc.)
 
 ### Path Parser
 Parses SCIM PATCH path expressions:
+
+#### Kotlin
 ```kotlin
 val path = PathParser.parse("emails[type eq \"work\"].value")
 // FilteredPath(attributeName="emails", filter=..., subAttribute="value")
 ```
 
+#### Java
+```java
+var path = PathParser.parse("emails[type eq \"work\"].value");
+// FilteredPath(attributeName="emails", filter=..., subAttribute="value")
+```
+
 ### PATCH Engine
 Applies SCIM PATCH operations to resources immutably:
+
+#### Kotlin
 ```kotlin
 val engine = PatchEngine(objectMapper)
 val updated = engine.apply(user, patchRequest)
+```
+
+#### Java
+```java
+var engine = new PatchEngine(objectMapper);
+var updated = engine.apply(user, patchRequest);
 ```
 
 ### Serialization SPI

--- a/scim2-sdk-server/README.md
+++ b/scim2-sdk-server/README.md
@@ -6,13 +6,23 @@ This module provides the **SCIM Service Provider** framework -- the server-side 
 
 When organizations use IdPs like **Okta**, **Azure AD**, **Keycloak**, or **PingFederate**, those IdPs need to push user/group changes to your application. The SCIM 2.0 protocol (RFC 7644) standardizes this:
 
-```
-+----------------+    SCIM 2.0 Protocol    +-----------------------+
-|  Identity      |  ---- POST /Users --->  |  Your Application     |
-|  Provider      |  ---- PATCH /Users -->  |  (SCIM Service        |
-|  (Okta,        |  ---- DELETE /Users ->  |   Provider, using     |
-|   Azure AD)    |  <--- 201 Created ----  |   this SDK)           |
-+----------------+                          +-----------------------+
+```mermaid
+sequenceDiagram
+    participant IdP as Identity Provider<br/>(Okta, Azure AD, Keycloak)
+    participant App as Your Application<br/>(SCIM Service Provider)
+    participant DB as Your Database
+
+    IdP->>App: POST /scim/v2/Users (new employee)
+    App->>DB: INSERT user
+    App-->>IdP: 201 Created
+
+    IdP->>App: PATCH /scim/v2/Users/{id} (role change)
+    App->>DB: UPDATE user
+    App-->>IdP: 200 OK
+
+    IdP->>App: DELETE /scim/v2/Users/{id} (offboarding)
+    App->>DB: DELETE user
+    App-->>IdP: 204 No Content
 ```
 
 For example, when a new employee joins and is added in Okta, Okta sends a `POST /scim/v2/Users` request to your application. This module handles that request.
@@ -21,37 +31,53 @@ See: [Okta SCIM Integration Guide](https://help.okta.com/en-us/content/topics/ap
 
 ## Architecture (Hexagonal)
 
-```
-+------------------- Inbound -------------------+
-|  ScimController (Spring MVC)                   |
-|  JDK HttpServer (plain Kotlin)                 |
-|  Any HTTP framework                            |
-+--------------------+---------------------------+
-                     |
-         +-----------v--------------+
-         |  ScimEndpointDispatcher  | <-- Central routing engine
-         |  (framework-agnostic)    |
-         +-----------+--------------+
-                     |
-+--------------------+-------------------------+
-|  Inbound Ports     |     Outbound Ports       |
-|  ResourceHandler   |     ResourceRepository   |
-|  BulkHandler       |     IdentityResolver     |
-|  MeHandler         |     AuthorizationEval.   |
-|                    |     ScimEventPublisher    |
-|                    |     ScimOutboxPort        |
-+--------------------+-------------------------+
-                     |
-+--------------------v-------------------------+
-|  Your Implementation                          |
-|  (JPA, MongoDB, DynamoDB, custom...)          |
-+-----------------------------------------------+
+```mermaid
+graph TD
+    subgraph "Inbound Adapters"
+        SC[ScimController<br/>Spring MVC]
+        JDK[JDK HttpServer<br/>Plain Kotlin]
+    end
+
+    subgraph "Core Engine"
+        D[ScimEndpointDispatcher]
+    end
+
+    subgraph "Inbound Ports"
+        RH[ResourceHandler]
+        BH[BulkHandler]
+        MH[MeHandler]
+    end
+
+    subgraph "Outbound Ports"
+        RR[ResourceRepository]
+        IR[IdentityResolver]
+        AE[AuthorizationEvaluator]
+        EP[ScimEventPublisher]
+    end
+
+    subgraph "Outbound Adapters<br/>(you provide or use OOTB)"
+        JPA[JPA Repository]
+        KC[Keycloak Resolver]
+        CUSTOM[Your Custom Impl]
+    end
+
+    SC --> D
+    JDK --> D
+    D --> RH & BH & MH
+    RH --> RR
+    D --> IR & AE & EP
+    RR --> JPA & CUSTOM
+    IR --> KC
+
+    style D fill:#4CAF50,color:#fff
 ```
 
 ## Key Interfaces
 
 ### ResourceHandler<T> (you implement this)
 Handles CRUD + search for a specific resource type:
+
+#### Kotlin
 ```kotlin
 class MyUserHandler : ResourceHandler<User> {
     override val resourceType = User::class.java
@@ -62,8 +88,21 @@ class MyUserHandler : ResourceHandler<User> {
 }
 ```
 
+#### Java
+```java
+public class MyUserHandler implements ResourceHandler<User> {
+    @Override public Class<User> getResourceType() { return User.class; }
+    @Override public String getEndpoint() { return "/Users"; }
+    @Override public User create(User resource, ScimRequestContext context) { ... }
+    @Override public User get(ResourceId id, ScimRequestContext context) { ... }
+    // ... replace, patch, delete, search
+}
+```
+
 ### ResourceRepository<T> (persistence abstraction)
 Generic persistence port -- no database opinion:
+
+#### Kotlin
 ```kotlin
 class MyUserRepository : ResourceRepository<User> {
     override fun create(resource: User): User { ... }
@@ -72,11 +111,29 @@ class MyUserRepository : ResourceRepository<User> {
 }
 ```
 
+#### Java
+```java
+public class MyUserRepository implements ResourceRepository<User> {
+    @Override public User create(User resource) { ... }
+    @Override public User findById(String id) { ... }
+    // ... replace, delete, search
+}
+```
+
 ### IdentityResolver (authentication)
 Extracts the authenticated identity from the incoming request:
+
+#### Kotlin
 ```kotlin
 class MyIdentityResolver : IdentityResolver {
     override fun resolve(request: ScimHttpRequest): ScimRequestContext { ... }
+}
+```
+
+#### Java
+```java
+public class MyIdentityResolver implements IdentityResolver {
+    @Override public ScimRequestContext resolve(ScimHttpRequest request) { ... }
 }
 ```
 

--- a/scim2-sdk-spring-boot-autoconfigure/README.md
+++ b/scim2-sdk-spring-boot-autoconfigure/README.md
@@ -46,5 +46,116 @@ scim:
 
 Reference SQL schemas for PostgreSQL, MySQL, Oracle, MSSQL, H2 are in `src/main/resources/db/scim/`.
 
+## Database Schema
+
+### Single-Table JSON Storage Design
+
+The JPA adapter uses a single-table design where all SCIM resource types (Users, Groups, custom types) are stored in one table, discriminated by `resource_type`. The full SCIM resource is preserved as JSON in the `resource_json` column, enabling schema-less flexibility while maintaining queryable metadata columns.
+
+This approach means:
+- Any SCIM resource type can be stored without DDL changes
+- The full resource fidelity is preserved (no attribute mapping/loss)
+- Metadata columns (`resource_type`, `external_id`, `display_name`) enable efficient queries
+- ETag-based optimistic concurrency via the `version` column
+
+### Table Structure
+
+```sql
+CREATE TABLE scim_resources (
+    id              VARCHAR(255) NOT NULL PRIMARY KEY,
+    resource_type   VARCHAR(100) NOT NULL,    -- "User", "Group", etc.
+    external_id     VARCHAR(255),
+    display_name    VARCHAR(500),
+    resource_json   TEXT NOT NULL,             -- Full SCIM resource as JSON
+    version         BIGINT NOT NULL DEFAULT 1, -- ETag version
+    created         TIMESTAMP NOT NULL,
+    last_modified   TIMESTAMP NOT NULL
+);
+```
+
+### Database-Specific SQL Files
+
+- [PostgreSQL](src/main/resources/db/scim/schema-postgresql.sql)
+- [MySQL](src/main/resources/db/scim/schema-mysql.sql)
+- [Oracle](src/main/resources/db/scim/schema-oracle.sql)
+- [MS SQL Server](src/main/resources/db/scim/schema-mssql.sql)
+- [H2 (testing)](src/main/resources/db/scim/schema-h2.sql)
+
+### Customizing Table and Schema Name
+
+```yaml
+scim:
+  persistence:
+    enabled: true
+    table-name: my_scim_resources   # default: scim_resources
+    schema-name: my_schema          # default: datasource default schema
+```
+
+### Enabling Auto-Migration
+
+When Flyway is on the classpath, you can opt in to automatic schema creation:
+
+```yaml
+scim:
+  persistence:
+    enabled: true
+    auto-migrate: true    # runs Flyway migration for SCIM tables
+```
+
+This uses a separate Flyway history table (`scim_flyway_history`) so it does not conflict with your application's own migrations. Requires `org.flywaydb:flyway-core` on the classpath.
+
+## Custom Handler Example
+
+### Kotlin
+```kotlin
+@Component
+class CustomUserHandler(private val userService: UserService) : ResourceHandler<User> {
+    override val resourceType = User::class.java
+    override val endpoint = "/Users"
+    override fun create(resource: User, context: ScimRequestContext) = userService.create(resource)
+}
+```
+
+### Java
+```java
+@Component
+public class CustomUserHandler implements ResourceHandler<User> {
+    private final UserService userService;
+    public CustomUserHandler(UserService userService) { this.userService = userService; }
+    @Override public Class<User> getResourceType() { return User.class; }
+    @Override public String getEndpoint() { return "/Users"; }
+    @Override public User create(User resource, ScimRequestContext context) {
+        return userService.create(resource);
+    }
+}
+```
+
+## Custom Identity Resolver Example
+
+### Kotlin
+```kotlin
+@Component
+class CustomIdentityResolver : IdentityResolver {
+    override fun resolve(request: ScimHttpRequest): ScimRequestContext {
+        val token = request.headers["Authorization"]?.removePrefix("Bearer ")
+        // your authentication logic
+        return ScimRequestContext(subject = token ?: "anonymous")
+    }
+}
+```
+
+### Java
+```java
+@Component
+public class CustomIdentityResolver implements IdentityResolver {
+    @Override
+    public ScimRequestContext resolve(ScimHttpRequest request) {
+        String auth = request.getHeaders().get("Authorization");
+        String token = auth != null ? auth.replace("Bearer ", "") : "anonymous";
+        return new ScimRequestContext(token);
+    }
+}
+```
+
 ## Every bean backs off
 Every auto-configured bean uses `@ConditionalOnMissingBean`. Provide your own implementation and the auto-configured one disappears.

--- a/scim2-sdk-test/README.md
+++ b/scim2-sdk-test/README.md
@@ -6,28 +6,53 @@ Test utilities, contract test base classes, and in-memory implementations for te
 
 ### InMemoryResourceRepository
 A `ConcurrentHashMap`-backed `ResourceRepository<T>` for testing:
+
+#### Kotlin
 ```kotlin
 val repo = InMemoryResourceRepository<User>()
 ```
 
+#### Java
+```java
+var repo = new InMemoryResourceRepository<User>();
+```
+
 ### InMemoryResourceHandler
 A `ResourceHandler<T>` backed by `InMemoryResourceRepository`:
+
+#### Kotlin
 ```kotlin
 val handler = InMemoryResourceHandler(User::class.java, "/Users", repo)
 ```
 
+#### Java
+```java
+var handler = new InMemoryResourceHandler<>(User.class, "/Users", repo);
+```
+
 ### InMemoryScimServer
 A complete SCIM server for integration testing:
+
+#### Kotlin
 ```kotlin
 val server = InMemoryScimServer()
 server.createUser(User(userName = "test"))
 val response = server.dispatch(ScimHttpRequest(GET, "/scim/v2/Users"))
 ```
 
+#### Java
+```java
+var server = new InMemoryScimServer();
+server.createUser(new User("test"));
+var response = server.dispatch(new ScimHttpRequest(GET, "/scim/v2/Users"));
+```
+
 ## Contract Tests
 
 ### ResourceHandlerContractTest
 Abstract base class with 23 tests. Extend it to prove your `ResourceHandler` implementation is correct:
+
+#### Kotlin
 ```kotlin
 class MyUserHandlerTest : ResourceHandlerContractTest<User>() {
     override fun createHandler() = MyUserHandler()
@@ -36,12 +61,33 @@ class MyUserHandlerTest : ResourceHandlerContractTest<User>() {
 }
 ```
 
+#### Java
+```java
+public class MyUserHandlerTest extends ResourceHandlerContractTest<User> {
+    @Override protected ResourceHandler<User> createHandler() { return new MyUserHandler(); }
+    @Override protected User sampleResource() { return new User("test"); }
+    @Override protected User modifiedResource(User original) {
+        return original.withDisplayName("Modified");
+    }
+}
+```
+
 ### ScimApiContractTest
 Abstract base class with 19 HTTP-level tests validating RFC 7644/7643 compliance. Each test references the specific RFC section:
+
+#### Kotlin
 ```kotlin
 class MyApiContractTest : ScimApiContractTest() {
     override fun createDispatcher() = myDispatcher
     override fun sampleUserJson() = serializer.serialize(User(userName = "test"))
+}
+```
+
+#### Java
+```java
+public class MyApiContractTest extends ScimApiContractTest {
+    @Override protected ScimEndpointDispatcher createDispatcher() { return myDispatcher; }
+    @Override protected byte[] sampleUserJson() { return serializer.serialize(new User("test")); }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Root README modules table now links to each module directory and its README, including the BOM module
- Root README Database Support section includes inline schema preview, links to all 5 DB-specific SQL files, and Flyway opt-in note
- Server README replaces ASCII art diagrams with Mermaid (sequence diagram for IdP flow, graph for hexagonal architecture)
- Java examples added to all module READMEs: core, server, client transports (httpclient, okhttp), test, and autoconfigure
- Autoconfigure README gains a full Database Schema section explaining the single-table JSON design, table structure, customization, and auto-migration
- Remaining hardcoded test values ("john", "u1", "g1", "admins") in DefaultScimClientTest and ScimClientExtensionsTest replaced with faker/UUID-generated values (filter DSL tests skipped as they test parsing syntax)

## Test plan
- [ ] Verify all Mermaid diagrams render correctly on GitHub
- [ ] Verify all relative links in root README resolve to correct module READMEs
- [ ] Verify DB schema SQL file links resolve correctly
- [ ] Run `mvn clean verify` to confirm test changes compile and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)