### PR TITLE
docs: Enhanced property descriptions with RFC links and namastack-outbox fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,18 +216,28 @@ All properties are optional with sensible defaults:
 
 | Property | Default | Description |
 |---|---|---|
-| `scim.base-path` | `/scim/v2` | Base path for SCIM endpoints |
-| `scim.persistence.enabled` | `false` | Enable JPA-backed persistence |
-| `scim.persistence.table-name` | `scim_resources` | Database table name |
-| `scim.persistence.schema-name` | (none) | Database schema name |
-| `scim.bulk.enabled` | `true` | Enable bulk operations |
-| `scim.bulk.max-operations` | `1000` | Max operations per bulk request |
-| `scim.filter.enabled` | `true` | Enable filtering |
-| `scim.filter.max-results` | `200` | Max results per filtered query |
-| `scim.etag.enabled` | `true` | Enable ETag support |
-| `scim.patch.enabled` | `true` | Enable PATCH operations |
-| `scim.sort.enabled` | `false` | Enable sorting |
-| `scim.client.base-url` | (none) | SCIM client target URL |
+| `scim.base-path` | `/scim/v2` | Base URL path for all SCIM endpoints |
+| `scim.bulk.enabled` | `true` | Enable [Bulk Operations (RFC 7644 §3.7)](https://www.rfc-editor.org/rfc/rfc7644#section-3.7) — allows clients to batch multiple create/update/delete operations into a single HTTP request, reducing round-trips for large provisioning jobs |
+| `scim.bulk.max-operations` | `1000` | Maximum number of individual operations allowed in a single bulk request |
+| `scim.bulk.max-payload-size` | `1048576` | Maximum payload size (bytes) for bulk requests (default: 1 MB) |
+| `scim.filter.enabled` | `true` | Enable [Filtering (RFC 7644 §3.4.2.2)](https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.2) — allows clients to query resources using expressions like `userName eq "john"` or `emails[type eq "work"]` |
+| `scim.filter.max-results` | `200` | Maximum number of resources returned by a filtered query |
+| `scim.etag.enabled` | `true` | Enable [ETags (RFC 7644 §3.14)](https://www.rfc-editor.org/rfc/rfc7644#section-3.14) — optimistic concurrency control using `If-Match` / `If-None-Match` headers to prevent lost updates when multiple clients modify the same resource |
+| `scim.patch.enabled` | `true` | Enable [PATCH Operations (RFC 7644 §3.5.2)](https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2) — partial resource updates (add/remove/replace individual attributes) without replacing the entire resource |
+| `scim.sort.enabled` | `false` | Enable [Sorting (RFC 7644 §3.4.2.3)](https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.3) — allows clients to sort search results using `sortBy` and `sortOrder` query parameters |
+| `scim.change-password.enabled` | `false` | Enable [Change Password (RFC 7644 §3.5.2.1)](https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2) — indicates the service provider supports password changes via PATCH |
+| `scim.pagination.default-page-size` | `100` | Default number of resources returned per page when the client doesn't specify `count` |
+| `scim.pagination.max-page-size` | `1000` | Maximum allowed page size — the server caps the client's `count` parameter to this value |
+| `scim.persistence.enabled` | `false` | Enable the OOTB JPA persistence adapter — stores SCIM resources in a relational database |
+| `scim.persistence.table-name` | `scim_resources` | Database table name for SCIM resource storage |
+| `scim.persistence.schema-name` | *(none)* | Database schema name (e.g., `scim`) — if set, the table is qualified as `schema.table` |
+| `scim.persistence.auto-migrate` | `false` | Run [Flyway](https://flywaydb.org/) migration on startup to create the `scim_resources` table automatically |
+| `scim.client.base-url` | *(none)* | Base URL of the remote SCIM Service Provider — when set, auto-configures a `ScimClient` bean |
+| `scim.client.connect-timeout` | `10s` | TCP connection timeout for the SCIM client |
+| `scim.client.read-timeout` | `30s` | Read timeout for the SCIM client |
+| `scim.idp.provider` | *(none)* | Identity Provider type: `keycloak`, `okta`, `azure-ad`, `ping-federate`, `auth0` — auto-configures the corresponding `IdentityResolver` |
+| `scim.idp.client-id` | *(none)* | Client ID for Keycloak client-role extraction |
+| `scim.idp.namespace` | *(none)* | Auth0 custom namespace for role claims |
 
 ## Database Support
 

--- a/docs/outbox-pattern.md
+++ b/docs/outbox-pattern.md
@@ -40,9 +40,10 @@ interface ScimOutboxPort {
 
 ### Option 1: namastack-outbox (Recommended)
 
-[namastack-outbox](https://github.com/namastack/namastack-outbox) integrates with Spring Modulith for transactional event publishing.
+[namastack-outbox](https://github.com/namastack/namastack-outbox) provides transactional outbox support and is available in Maven Central. It integrates with Spring Modulith's event externalization.
 
 Add the dependency:
+
 ```xml
 <dependency>
     <groupId>com.namastack</groupId>
@@ -51,66 +52,15 @@ Add the dependency:
 </dependency>
 ```
 
-Configure:
+Configure in `application.yml`:
+
 ```yaml
 scim:
   outbox:
     enabled: true
 ```
 
-The SDK auto-configures a `NamastackOutboxAdapter` that implements `ScimOutboxPort` and delegates to namastack-outbox's `OutboxPublisher`.
-
-#### Adapter Code
-
-Since namastack-outbox may not yet be available in Maven Central, you can create the adapter manually in your project:
-
-```kotlin
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.marcosbarbero.scim2.core.event.ScimEvent
-import com.marcosbarbero.scim2.server.port.ScimOutboxPort
-// import com.namastack.outbox.OutboxPublisher  // from namastack-outbox
-import org.springframework.stereotype.Component
-
-/**
- * Bridges [ScimOutboxPort] to namastack-outbox's [OutboxPublisher].
- *
- * Each [ScimEvent] is mapped to an outbox message with:
- * - aggregateType = "ScimResource"
- * - aggregateId   = event.resourceId
- * - eventType     = event's simple class name (e.g., "ResourceCreatedEvent")
- * - payload       = JSON-serialized event
- *
- * namastack-outbox handles persistence in the same DB transaction and
- * asynchronous relay to the configured message broker (Kafka, SQS, etc.).
- */
-@Component
-class NamastackOutboxAdapter(
-    private val outboxPublisher: Any, // OutboxPublisher — replace with actual type
-    private val objectMapper: ObjectMapper
-) : ScimOutboxPort {
-
-    override fun store(event: ScimEvent) {
-        val payload = objectMapper.writeValueAsString(event)
-
-        // Replace with actual namastack-outbox API call:
-        // outboxPublisher.publish(
-        //     OutboxMessage(
-        //         aggregateType = "ScimResource",
-        //         aggregateId = event.resourceId,
-        //         eventType = event::class.simpleName ?: "ScimEvent",
-        //         payload = payload,
-        //         headers = buildMap {
-        //             put("correlationId", event.correlationId ?: "")
-        //             put("resourceType", event.resourceType)
-        //             put("eventId", event.eventId)
-        //         }
-        //     )
-        // )
-    }
-}
-```
-
-Once namastack-outbox is published, replace the commented section with the actual API call and update the `outboxPublisher` type to `OutboxPublisher`.
+The SDK auto-configures a `NamastackOutboxAdapter` implementing `ScimOutboxPort` that delegates to namastack-outbox's event publishing. Events are stored transactionally alongside your resource changes and published asynchronously.
 
 ### Option 2: Custom Implementation
 

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3,78 +3,78 @@
     {
       "name": "scim.base-path",
       "type": "java.lang.String",
-      "description": "Base path for all SCIM 2.0 endpoints.",
+      "description": "Base URL path for all SCIM endpoints.",
       "defaultValue": "/scim/v2"
     },
     {
       "name": "scim.bulk.enabled",
       "type": "java.lang.Boolean",
-      "description": "Whether SCIM bulk operations are enabled.",
+      "description": "Enable Bulk Operations (RFC 7644 §3.7) — allows clients to batch multiple create/update/delete operations into a single HTTP request, reducing round-trips for large provisioning jobs.",
       "defaultValue": true
     },
     {
       "name": "scim.bulk.max-operations",
       "type": "java.lang.Integer",
-      "description": "Maximum number of operations in a single bulk request.",
+      "description": "Maximum number of individual operations allowed in a single bulk request.",
       "defaultValue": 1000
     },
     {
       "name": "scim.bulk.max-payload-size",
       "type": "java.lang.Long",
-      "description": "Maximum payload size in bytes for bulk requests.",
+      "description": "Maximum payload size (bytes) for bulk requests (default: 1 MB).",
       "defaultValue": 1048576
     },
     {
       "name": "scim.filter.enabled",
       "type": "java.lang.Boolean",
-      "description": "Whether SCIM filtering is enabled.",
+      "description": "Enable Filtering (RFC 7644 §3.4.2.2) — allows clients to query resources using expressions like 'userName eq \"john\"' or 'emails[type eq \"work\"]'.",
       "defaultValue": true
     },
     {
       "name": "scim.filter.max-results",
       "type": "java.lang.Integer",
-      "description": "Maximum number of results returned by a filtered query.",
+      "description": "Maximum number of resources returned by a filtered query.",
       "defaultValue": 200
     },
     {
       "name": "scim.pagination.default-page-size",
       "type": "java.lang.Integer",
-      "description": "Default page size when count is not specified.",
+      "description": "Default number of resources returned per page when the client doesn't specify 'count'.",
       "defaultValue": 100
     },
     {
       "name": "scim.pagination.max-page-size",
       "type": "java.lang.Integer",
-      "description": "Maximum allowed page size.",
+      "description": "Maximum allowed page size — the server caps the client's 'count' parameter to this value.",
       "defaultValue": 1000
     },
     {
       "name": "scim.etag.enabled",
       "type": "java.lang.Boolean",
-      "description": "Whether ETag support is enabled for optimistic concurrency.",
+      "description": "Enable ETags (RFC 7644 §3.14) — optimistic concurrency control using If-Match / If-None-Match headers to prevent lost updates when multiple clients modify the same resource.",
       "defaultValue": true
     },
     {
       "name": "scim.patch.enabled",
       "type": "java.lang.Boolean",
-      "description": "Whether SCIM PATCH operations are enabled.",
+      "description": "Enable PATCH Operations (RFC 7644 §3.5.2) — partial resource updates (add/remove/replace individual attributes) without replacing the entire resource.",
       "defaultValue": true
     },
     {
       "name": "scim.sort.enabled",
       "type": "java.lang.Boolean",
-      "description": "Whether SCIM sorting is enabled.",
+      "description": "Enable Sorting (RFC 7644 §3.4.2.3) — allows clients to sort search results using 'sortBy' and 'sortOrder' query parameters.",
       "defaultValue": false
     },
     {
       "name": "scim.client.base-url",
       "type": "java.lang.String",
-      "description": "Base URL of the remote SCIM service provider."
+      "description": "Base URL of the remote SCIM Service Provider — when set, auto-configures a ScimClient bean."
     },
     {
       "name": "scim.client.connect-timeout",
       "type": "java.time.Duration",
-      "description": "Connection timeout for the SCIM client.",
+      "description": "TCP connection timeout for the SCIM client.",
       "defaultValue": "10s"
     },
     {
@@ -86,40 +86,40 @@
     {
       "name": "scim.persistence.enabled",
       "type": "java.lang.Boolean",
-      "description": "Whether the JPA-based SCIM persistence adapter is enabled.",
+      "description": "Enable the OOTB JPA persistence adapter — stores SCIM resources in a relational database.",
       "defaultValue": false
     },
     {
       "name": "scim.persistence.table-name",
       "type": "java.lang.String",
-      "description": "Name of the database table used to store SCIM resources.",
+      "description": "Database table name for SCIM resource storage.",
       "defaultValue": "scim_resources"
     },
     {
       "name": "scim.persistence.schema-name",
       "type": "java.lang.String",
-      "description": "Database schema name for the SCIM resources table."
+      "description": "Database schema name (e.g., 'scim') — if set, the table is qualified as schema.table."
     },
     {
       "name": "scim.persistence.auto-migrate",
       "type": "java.lang.Boolean",
-      "description": "Whether to automatically run Flyway migrations for the SCIM schema. When enabled, creates the scim_resources table on startup.",
+      "description": "Run Flyway migration on startup to create the scim_resources table automatically.",
       "defaultValue": false
     },
     {
       "name": "scim.idp.provider",
       "type": "java.lang.String",
-      "description": "Identity provider to auto-configure. Supported values: keycloak, okta, azure-ad, ping-federate, auth0."
+      "description": "Identity Provider type: keycloak, okta, azure-ad, ping-federate, auth0 — auto-configures the corresponding IdentityResolver."
     },
     {
       "name": "scim.idp.client-id",
       "type": "java.lang.String",
-      "description": "Client ID for Keycloak client-level role extraction from the resource_access claim."
+      "description": "Client ID for Keycloak client-role extraction."
     },
     {
       "name": "scim.idp.namespace",
       "type": "java.lang.String",
-      "description": "Custom namespace for Auth0 role claims (e.g., https://your-app.auth0.com).",
+      "description": "Auth0 custom namespace for role claims (e.g., https://your-app.auth0.com).",
       "defaultValue": "https://your-app.auth0.com"
     },
     {


### PR DESCRIPTION
## Summary
- Enriched README configuration properties table with SCIM feature explanations and RFC 7644 section links (bulk, filter, etag, patch, sort, change-password)
- Added missing properties to the table: `bulk.max-payload-size`, `change-password.enabled`, `pagination.*`, `persistence.auto-migrate`, `client.*`, `idp.*`
- Updated `additional-spring-configuration-metadata.json` descriptions to match, improving IDE tooltip quality
- Fixed incorrect statement in `docs/outbox-pattern.md` claiming namastack-outbox "may not yet be available in Maven Central" — it IS available and removed the manual adapter workaround code

## Test plan
- [ ] Verify README table renders correctly in GitHub
- [ ] Verify IDE tooltips show enhanced descriptions from metadata JSON
- [ ] Verify outbox-pattern.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)