### PR TITLE
refactor: Rename JavaHttpClientTransport to HttpClientTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ See [sample-server-plain](scim2-sdk-samples/sample-server-plain/) for a complete
 // Create client
 val client = ScimClientBuilder()
     .baseUrl("https://scim.example.com/scim/v2")
-    .transport(JavaHttpClientTransport())
+    .transport(HttpClientTransport())
     .serializer(JacksonScimSerializer())
     .authentication(BearerTokenAuthentication("your-token"))
     .build()
@@ -180,7 +180,7 @@ val results = client.search("/Users", searchRequest, User::class)
 ```java
 ScimClient client = new ScimClientBuilder()
     .baseUrl("https://scim.example.com/scim/v2")
-    .transport(new JavaHttpClientTransport())
+    .transport(new HttpClientTransport())
     .serializer(new JacksonScimSerializer())
     .authentication(new BearerTokenAuthentication("your-token"))
     .build();

--- a/docs/adr/0020-spring-boot-autoconfiguration.md
+++ b/docs/adr/0020-spring-boot-autoconfiguration.md
@@ -20,7 +20,7 @@ Five auto-configuration classes, ordered by dependency:
 
 2. **ScimServerAutoConfiguration** - Wires `ScimServerConfig` from `ScimProperties` (`@ConfigurationProperties(prefix = "scim")`), creates `SchemaRegistry` (auto-registers resource types from all `ResourceHandler` beans), `DiscoveryService`, and `ScimEndpointDispatcher`. Optional beans (`BulkHandler`, `MeHandler`, `IdentityResolver`, `AuthorizationEvaluator`, `ScimEventPublisher`, `ScimMetrics`, `ScimTracer`, `ScimInterceptor`) are injected via `ObjectProvider` with graceful fallbacks.
 
-3. **ScimClientAutoConfiguration** - Creates `HttpTransport` (defaults to `JavaHttpClientTransport`) and `ScimClient` when `scim.client.base-url` is set. Optional `AuthenticationStrategy` bean is auto-detected.
+3. **ScimClientAutoConfiguration** - Creates `HttpTransport` (defaults to `HttpClientTransport`) and `ScimClient` when `scim.client.base-url` is set. Optional `AuthenticationStrategy` bean is auto-detected.
 
 4. **ScimWebAutoConfiguration** - Registers `ScimController` (Spring MVC adapter mapping `${scim.base-path}/**` to `ScimEndpointDispatcher`) and `ScimExceptionHandler` (`@ControllerAdvice` converting `ScimException` to SCIM JSON error responses). Only activates in servlet web applications.
 

--- a/scim2-sdk-client-httpclient/README.md
+++ b/scim2-sdk-client-httpclient/README.md
@@ -6,9 +6,9 @@
 
 ### Kotlin
 ```kotlin
-val transport = JavaHttpClientTransport()
+val transport = HttpClientTransport()
 // or with custom HttpClient:
-val transport = JavaHttpClientTransport(
+val transport = HttpClientTransport(
     HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
         .build()
@@ -22,9 +22,9 @@ val client = ScimClientBuilder()
 
 ### Java
 ```java
-var transport = new JavaHttpClientTransport();
+var transport = new HttpClientTransport();
 // or with custom HttpClient:
-var transport = new JavaHttpClientTransport(
+var transport = new HttpClientTransport(
     HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
         .build()

--- a/scim2-sdk-client-httpclient/src/main/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/HttpClientTransport.kt
+++ b/scim2-sdk-client-httpclient/src/main/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/HttpClientTransport.kt
@@ -6,7 +6,7 @@ import com.marcosbarbero.scim2.client.port.HttpTransport
 import java.net.URI
 import java.net.http.HttpClient
 
-class JavaHttpClientTransport(
+class HttpClientTransport(
     private val httpClient: HttpClient = HttpClient.newHttpClient()
 ) : HttpTransport {
 

--- a/scim2-sdk-client-httpclient/src/test/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/HttpClientTransportTest.kt
+++ b/scim2-sdk-client-httpclient/src/test/kotlin/com/marcosbarbero/scim2/client/adapter/httpclient/HttpClientTransportTest.kt
@@ -10,18 +10,18 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.net.InetSocketAddress
 
-class JavaHttpClientTransportTest {
+class HttpClientTransportTest {
 
     private val faker = Faker()
     private lateinit var server: HttpServer
-    private lateinit var transport: JavaHttpClientTransport
+    private lateinit var transport: HttpClientTransport
     private var port: Int = 0
 
     @BeforeEach
     fun setUp() {
         server = HttpServer.create(InetSocketAddress(0), 0)
         port = server.address.port
-        transport = JavaHttpClientTransport()
+        transport = HttpClientTransport()
     }
 
     @AfterEach

--- a/scim2-sdk-client/README.md
+++ b/scim2-sdk-client/README.md
@@ -8,7 +8,7 @@ Type-safe SCIM 2.0 client for consuming SCIM Service Provider APIs. Use this to 
 ```kotlin
 val client = ScimClientBuilder()
     .baseUrl("https://scim.example.com/scim/v2")
-    .transport(JavaHttpClientTransport())
+    .transport(HttpClientTransport())
     .serializer(JacksonScimSerializer())
     .authentication(BearerTokenAuthentication(token))
     .build()
@@ -25,7 +25,7 @@ client.deleteUser(user.id!!)
 ```java
 ScimClient client = new ScimClientBuilder()
     .baseUrl("https://scim.example.com/scim/v2")
-    .transport(new JavaHttpClientTransport())
+    .transport(new HttpClientTransport())
     .serializer(new JacksonScimSerializer())
     .authentication(new BearerTokenAuthentication(token))
     .build();

--- a/scim2-sdk-samples/sample-server-java/src/test/java/com/marcosbarbero/scim2/sample/java/SampleServerJavaE2eTest.java
+++ b/scim2-sdk-samples/sample-server-java/src/test/java/com/marcosbarbero/scim2/sample/java/SampleServerJavaE2eTest.java
@@ -1,7 +1,7 @@
 package com.marcosbarbero.scim2.sample.java;
 
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.marcosbarbero.scim2.client.adapter.httpclient.JavaHttpClientTransport;
+import com.marcosbarbero.scim2.client.adapter.httpclient.HttpClientTransport;
 import com.marcosbarbero.scim2.client.api.ScimClient;
 import com.marcosbarbero.scim2.client.api.ScimClientBuilder;
 import com.marcosbarbero.scim2.client.api.ScimResponse;
@@ -58,7 +58,7 @@ class SampleServerJavaE2eTest {
     void setup() {
         client = new ScimClientBuilder()
                 .baseUrl("http://localhost:" + port + "/scim/v2")
-                .transport(new JavaHttpClientTransport())
+                .transport(new HttpClientTransport())
                 .serializer(new JacksonScimSerializer())
                 .build();
     }

--- a/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakE2eTest.kt
+++ b/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakE2eTest.kt
@@ -1,7 +1,7 @@
 package com.marcosbarbero.scim2.sample.spring
 
 import com.fasterxml.jackson.databind.node.TextNode
-import com.marcosbarbero.scim2.client.adapter.httpclient.JavaHttpClientTransport
+import com.marcosbarbero.scim2.client.adapter.httpclient.HttpClientTransport
 import com.marcosbarbero.scim2.client.api.ScimClient
 import com.marcosbarbero.scim2.client.api.ScimClientBuilder
 import com.marcosbarbero.scim2.client.api.create
@@ -80,7 +80,7 @@ class KeycloakE2eTest {
         val token = obtainAccessToken()
         client = ScimClientBuilder()
             .baseUrl("http://localhost:$port/scim/v2")
-            .transport(JavaHttpClientTransport())
+            .transport(HttpClientTransport())
             .serializer(JacksonScimSerializer())
             .authentication(BearerTokenAuthentication(token))
             .build()
@@ -101,7 +101,7 @@ class KeycloakE2eTest {
     fun `unauthenticated request returns 401`() {
         val unauthenticatedClient = ScimClientBuilder()
             .baseUrl("http://localhost:$port/scim/v2")
-            .transport(JavaHttpClientTransport())
+            .transport(HttpClientTransport())
             .serializer(JacksonScimSerializer())
             .build()
 

--- a/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/SampleServerE2eTest.kt
+++ b/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/SampleServerE2eTest.kt
@@ -1,6 +1,6 @@
 package com.marcosbarbero.scim2.sample.spring
 
-import com.marcosbarbero.scim2.client.adapter.httpclient.JavaHttpClientTransport
+import com.marcosbarbero.scim2.client.adapter.httpclient.HttpClientTransport
 import com.marcosbarbero.scim2.client.api.ScimClient
 import com.marcosbarbero.scim2.client.api.ScimClientBuilder
 import com.marcosbarbero.scim2.client.api.create
@@ -39,7 +39,7 @@ class SampleServerE2eTest(@LocalServerPort val port: Int) {
     fun setup() {
         client = ScimClientBuilder()
             .baseUrl("http://localhost:$port/scim/v2")
-            .transport(JavaHttpClientTransport())
+            .transport(HttpClientTransport())
             .serializer(JacksonScimSerializer())
             .build()
     }

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimClientAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimClientAutoConfiguration.kt
@@ -1,6 +1,6 @@
 package com.marcosbarbero.scim2.spring.autoconfigure
 
-import com.marcosbarbero.scim2.client.adapter.httpclient.JavaHttpClientTransport
+import com.marcosbarbero.scim2.client.adapter.httpclient.HttpClientTransport
 import com.marcosbarbero.scim2.client.api.ScimClient
 import com.marcosbarbero.scim2.client.api.ScimClientBuilder
 import com.marcosbarbero.scim2.client.port.AuthenticationStrategy
@@ -22,7 +22,7 @@ class ScimClientAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(HttpTransport::class)
-    fun httpTransport(): HttpTransport = JavaHttpClientTransport()
+    fun httpTransport(): HttpTransport = HttpClientTransport()
 
     @Bean
     @ConditionalOnMissingBean(ScimClient::class)


### PR DESCRIPTION
## Summary
- Rename `JavaHttpClientTransport` to `HttpClientTransport` across the entire codebase
- Removes the redundant "Java" prefix — there is only one JDK HttpClient transport, no need to distinguish from a non-existent Kotlin variant

## Changes
- Renamed source file and class: `JavaHttpClientTransport` -> `HttpClientTransport`
- Renamed test file and class: `JavaHttpClientTransportTest` -> `HttpClientTransportTest`
- Updated all references in imports, documentation (READMEs, ADRs), auto-configuration, and sample projects

## Test plan
- [x] `mvn clean verify` passes (all 13 modules BUILD SUCCESS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)