### PR TITLE
fix: Release readiness for 1.0.0-M1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
           path: '**/target/site/jacoco/'
           retention-days: 7
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: false
+
   mutation-tests:
     name: Mutation Tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ out/
 # Test
 *.log
 hs_err_pid*
-.claude/worktrees/
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to the SCIM 2.0 SDK for JVM will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-M1] - 2026-03-25
+
+### Added
+- **Core module** (`scim2-sdk-core`)
+  - SCIM 2.0 domain model: User, Group, EnterpriseUserExtension (RFC 7643)
+  - Recursive-descent filter parser with visitor pattern (RFC 7644 S3.4.2.2)
+  - PATCH operation engine with add/remove/replace and filtered paths (RFC 7644 S3.5.2)
+  - Path parser for SCIM attribute paths
+  - Schema introspector and registry (annotation-driven)
+  - Jackson serialization SPI with ScimModule
+  - Event system: ScimEvent sealed hierarchy + ScimEventPublisher SPI
+  - Observability SPIs: ScimMetrics, ScimTracer
+  - RFC 9457 ProblemDetail support with content negotiation
+  - ScimUrns constants for all SCIM URN strings
+  - Attribute projector for include/exclude (RFC 7644 S3.4.2.5)
+  - ScimValidator for create/replace/patch validation
+
+- **Server module** (`scim2-sdk-server`)
+  - ScimEndpointDispatcher with case-insensitive routing
+  - All RFC 7644 endpoints: CRUD, search (GET + POST), bulk, /Me, discovery
+  - Port interfaces: ResourceHandler, ResourceRepository, IdentityResolver, AuthorizationEvaluator
+  - ETag engine with If-Match/If-None-Match (RFC 7644 S3.14)
+  - Pagination and bulk engines
+  - ScimInterceptor SPI for cross-cutting concerns
+  - ScimOutboxPort for transactional event publishing
+
+- **Client module** (`scim2-sdk-client`)
+  - Type-safe ScimClient: createUser(), getUser(), searchUsers(), etc.
+  - ScimClientBuilder with fluent API
+  - Kotlin DSLs: scimFilter {}, scimPatch {}, scimSearch {}
+  - AsyncScimClient with Kotlin coroutines
+  - Java-friendly ScimClients static methods
+  - AuthenticationStrategy SPI (Bearer, Basic)
+
+- **Transport adapters**
+  - `scim2-sdk-client-httpclient`: JDK HttpClient adapter
+  - `scim2-sdk-client-okhttp`: OkHttp adapter
+
+- **Spring Boot integration** (`scim2-sdk-spring-boot-autoconfigure` + `scim2-sdk-spring-boot-starter`)
+  - Auto-configuration with @ConditionalOnMissingBean back-off
+  - ScimProperties with IDE autocompletion
+  - ScimController (catch-all Spring MVC adapter)
+  - ScimExceptionHandler with content negotiation
+  - JPA persistence adapter with reference schemas for PostgreSQL, MySQL, Oracle, MSSQL, H2
+  - Flyway migration support (opt-in)
+  - IdP adapters: Keycloak, Okta, Azure AD, PingFederate, Auth0 (configurable claims)
+  - Micrometer metrics adapter
+
+- **Test module** (`scim2-sdk-test`)
+  - InMemoryResourceRepository and InMemoryResourceHandler
+  - InMemoryScimServer
+  - ResourceHandlerContractTest (23 tests per resource type)
+  - ScimApiContractTest (19 RFC-referenced HTTP-level tests)
+  - ArchUnit architectural boundary tests
+  - Pact CDC consumer tests
+
+- **Documentation**
+  - OpenAPI 3.1 specification
+  - Mermaid architecture diagrams (6 diagrams)
+  - Module-level READMEs with Kotlin and Java examples
+  - Keycloak integration guide
+  - Outbox pattern guide with real-world scenarios
+  - HTTP API reference with curl examples
+  - ADRs (24 decisions documented)
+  - Release guide
+
+- **CI/CD**
+  - GitHub Actions: build, test, mutation, release
+  - Release via GitHub UI or tag push
+  - Codecov integration
+
+[Unreleased]: https://github.com/marcosbarbero/scim2-sdk-jvm/compare/v1.0.0-M1...HEAD
+[1.0.0-M1]: https://github.com/marcosbarbero/scim2-sdk-jvm/releases/tag/v1.0.0-M1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Thank you for your interest in contributing to the SCIM 2.0 SDK for JVM!
+
+## Development Setup
+
+### Prerequisites
+- Java 25+
+- Maven 3.9+
+- Docker (for Testcontainers-based integration tests)
+
+### Build
+```bash
+mvn clean verify
+```
+
+### Run specific module tests
+```bash
+mvn clean verify -pl scim2-sdk-core -am
+```
+
+### Run mutation tests
+```bash
+mvn verify -Pmutation -pl scim2-sdk-core
+```
+
+## Workflow
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Write tests first (TDD)
+4. Implement the feature
+5. Create an ADR in `docs/adr/` for architectural decisions
+6. Open a Pull Request
+7. CI must pass (build, tests, coverage)
+
+## Coding Standards
+
+- **Kotlin-first** with full Java interop (`@JvmStatic`, `@JvmOverloads`)
+- **No wildcard imports**
+- **`internal` by default** -- only explicitly public API is `public`
+- **Sealed classes** for closed hierarchies
+- **Exhaustive `when`** -- no `else` on sealed classes
+- **`require()` / `check()`** over manual if/throw
+- **kotlin-faker** for all test data (no hardcoded strings)
+- **Extension functions** for type conversions
+
+## Architecture Rules
+
+- `scim2-sdk-core` has ZERO framework dependencies
+- Dependencies flow inward: adapters -> ports -> domain
+- Every bean in Spring auto-config uses `@ConditionalOnMissingBean`
+- All IdP claim names are configurable via properties
+
+## Adding a New IdP Adapter
+
+1. Create a new class extending `JwtIdentityResolver` in `spring/security/`
+2. Override `extractRoles()` and `extractAttributes()` for your IdP's claim format
+3. Add a `@ConditionalOnProperty` bean in `ScimIdentityAutoConfiguration`
+4. Add claim mapping properties to `ClaimMapping`
+5. Add tests
+6. Update documentation
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/docs/scim2-openapi.yaml
+++ b/docs/scim2-openapi.yaml
@@ -668,6 +668,45 @@ components:
             $ref: '#/components/schemas/MultiValuedAttribute'
         meta:
           $ref: '#/components/schemas/Meta'
+        urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:
+          $ref: '#/components/schemas/EnterpriseUserExtension'
+
+    EnterpriseUserExtension:
+      type: object
+      description: |
+        Enterprise User extension schema (RFC 7643 S4.3).
+        Schema URN: urn:ietf:params:scim:schemas:extension:enterprise:2.0:User
+      properties:
+        employeeNumber:
+          type: string
+          description: Numeric or alphanumeric identifier assigned to a person.
+        costCenter:
+          type: string
+          description: Identifies the name of a cost center.
+        organization:
+          type: string
+          description: Identifies the name of an organization.
+        division:
+          type: string
+          description: Identifies the name of a division.
+        department:
+          type: string
+          description: Identifies the name of a department.
+        manager:
+          type: object
+          description: The user's manager.
+          properties:
+            value:
+              type: string
+              description: The id of the SCIM resource representing the manager.
+            $ref:
+              type: string
+              format: uri
+              description: The URI of the SCIM resource representing the manager.
+            displayName:
+              type: string
+              readOnly: true
+              description: The displayName of the manager.
 
     Group:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,21 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <id>marcosbarbero</id>
+            <name>Marcos Barbero</name>
+            <email>marcos.hgb@gmail.com</email>
+            <url>https://github.com/marcosbarbero</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/marcosbarbero/scim2-sdk-jvm.git</connection>
+        <developerConnection>scm:git:ssh://github.com:marcosbarbero/scim2-sdk-jvm.git</developerConnection>
+        <url>https://github.com/marcosbarbero/scim2-sdk-jvm</url>
+    </scm>
+
     <modules>
         <module>scim2-sdk-bom</module>
         <module>scim2-sdk-core</module>
@@ -63,7 +78,7 @@
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
         <pitest-maven.version>1.17.4</pitest-maven.version>
@@ -317,6 +332,34 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.jetbrains.dokka</groupId>
+                    <artifactId>dokka-maven-plugin</artifactId>
+                    <version>2.0.0</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>dokkaJavadoc</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.pitest</groupId>
@@ -404,6 +447,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -436,16 +483,8 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/scim2-sdk-core/README.md
+++ b/scim2-sdk-core/README.md
@@ -64,6 +64,43 @@ var engine = new PatchEngine(objectMapper);
 var updated = engine.apply(user, patchRequest);
 ```
 
+### Extension Schemas
+
+SCIM supports extension schemas (RFC 7643 S3.3). The SDK includes the Enterprise User extension:
+
+#### Kotlin
+```kotlin
+val user = User(userName = "jane.doe")
+user.setExtension(
+    ScimUrns.ENTERPRISE_USER,
+    EnterpriseUserExtension(
+        employeeNumber = "12345",
+        department = "Engineering",
+        manager = Manager(value = "manager-id", displayName = "John Boss")
+    )
+)
+```
+
+#### Java
+```java
+var user = new User("jane.doe");
+user.setExtension(
+    ScimUrns.ENTERPRISE_USER,
+    new EnterpriseUserExtension("12345", "Engineering",
+        new Manager("manager-id", "John Boss"))
+);
+```
+
+Custom extensions can be defined using `@ScimExtension`:
+
+```kotlin
+@ScimExtension(schema = "urn:example:custom:1.0:Department")
+data class DepartmentExtension(
+    val departmentCode: String,
+    val costCenter: String
+)
+```
+
 ### Serialization SPI
 `ScimSerializer` interface with `JacksonScimSerializer` as the default implementation.
 

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResourceTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResourceTest.kt
@@ -54,6 +54,8 @@ class ScimResourceTest {
             val country = faker.address.country()
             val groupId = java.util.UUID.randomUUID().toString()
             val groupDisplay = faker.name.name()
+            val entitlement = faker.name.firstName().lowercase()
+            val role = faker.name.firstName().lowercase()
             val user = User(
                 id = id,
                 externalId = externalId,
@@ -113,10 +115,10 @@ class ScimResourceTest {
                     GroupMembership(value = groupId, display = groupDisplay)
                 ),
                 entitlements = listOf(
-                    MultiValuedAttribute(value = "admin")
+                    MultiValuedAttribute(value = entitlement)
                 ),
                 roles = listOf(
-                    MultiValuedAttribute(value = "manager")
+                    MultiValuedAttribute(value = role)
                 ),
                 x509Certificates = emptyList()
             )

--- a/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakE2eTest.kt
+++ b/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakE2eTest.kt
@@ -19,15 +19,14 @@ import dasniko.testcontainers.keycloak.KeycloakContainer
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -42,30 +41,43 @@ import java.net.http.HttpResponse
  * 2. Configures the Spring Boot SCIM server as an OAuth2 resource server
  * 3. Obtains an access token from Keycloak (client credentials grant)
  * 4. Uses ScimClient with BearerTokenAuthentication to call SCIM endpoints
- * 5. Verifies: create, get, search, patch, delete — all authenticated via Keycloak JWT
+ * 5. Verifies: create, get, search, patch, delete -- all authenticated via Keycloak JWT
  *
- * Requires Docker. Skipped when TESTCONTAINERS_DISABLED=true.
+ * Requires Docker. Automatically skipped when Docker is not available.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-@EnabledIfEnvironmentVariable(
-    named = "TESTCONTAINERS_DISABLED",
-    matches = "(?!true).*",
-    disabledReason = "Docker/Testcontainers not available"
-)
 class KeycloakE2eTest {
 
     companion object {
-        @Container
+        private var keycloak: KeycloakContainer? = null
+        private var dockerAvailable = false
+
+        init {
+            dockerAvailable = try {
+                org.testcontainers.DockerClientFactory.instance().isDockerAvailable
+            } catch (_: Exception) {
+                false
+            }
+            if (dockerAvailable) {
+                keycloak = KeycloakContainer("quay.io/keycloak/keycloak:26.0")
+                    .withRealmImportFile("test-realm.json")
+                keycloak!!.start()
+            }
+        }
+
+        @BeforeAll
         @JvmStatic
-        val keycloak = KeycloakContainer("quay.io/keycloak/keycloak:26.0")
-            .withRealmImportFile("test-realm.json")
+        fun checkDocker() {
+            assumeTrue(dockerAvailable, "Docker is not available -- skipping Keycloak E2E tests")
+        }
 
         @DynamicPropertySource
         @JvmStatic
         fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") {
-                "${keycloak.authServerUrl}/realms/scim-test"
+            if (dockerAvailable) {
+                registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") {
+                    "${keycloak!!.authServerUrl}/realms/scim-test"
+                }
             }
         }
     }
@@ -154,7 +166,7 @@ class KeycloakE2eTest {
     }
 
     private fun obtainAccessToken(): String {
-        val tokenUrl = "${keycloak.authServerUrl}/realms/scim-test/protocol/openid-connect/token"
+        val tokenUrl = "${keycloak!!.authServerUrl}/realms/scim-test/protocol/openid-connect/token"
 
         val formData = listOf(
             "grant_type" to "client_credentials",

--- a/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakScimProvisioningE2eTest.kt
+++ b/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakScimProvisioningE2eTest.kt
@@ -23,18 +23,17 @@ import dasniko.testcontainers.keycloak.KeycloakContainer
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -61,18 +60,12 @@ import java.net.http.HttpResponse
  * This proves the SDK works correctly as a Service Provider receiving provisioning
  * from Keycloak-issued tokens and Keycloak-shaped user data.
  *
- * Requires Docker. Skipped when `TESTCONTAINERS_DISABLED=true`.
+ * Requires Docker. Automatically skipped when Docker is not available.
  *
  * @see <a href="https://github.com/Captain-P-Goldfish/scim-for-keycloak">scim-for-keycloak extension</a>
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-@EnabledIfEnvironmentVariable(
-    named = "TESTCONTAINERS_DISABLED",
-    matches = "(?!true).*",
-    disabledReason = "Docker/Testcontainers not available"
-)
 class KeycloakScimProvisioningE2eTest {
 
     companion object {
@@ -83,16 +76,35 @@ class KeycloakScimProvisioningE2eTest {
         private val objectMapper = ObjectMapper()
         private val httpClient = HttpClient.newHttpClient()
 
-        @Container
+        private var keycloak: KeycloakContainer? = null
+        private var dockerAvailable = false
+
+        init {
+            dockerAvailable = try {
+                org.testcontainers.DockerClientFactory.instance().isDockerAvailable
+            } catch (_: Exception) {
+                false
+            }
+            if (dockerAvailable) {
+                keycloak = KeycloakContainer("quay.io/keycloak/keycloak:26.0")
+                    .withRealmImportFile("test-realm.json")
+                keycloak!!.start()
+            }
+        }
+
+        @BeforeAll
         @JvmStatic
-        val keycloak = KeycloakContainer("quay.io/keycloak/keycloak:26.0")
-            .withRealmImportFile("test-realm.json")
+        fun checkDocker() {
+            assumeTrue(dockerAvailable, "Docker is not available -- skipping Keycloak E2E tests")
+        }
 
         @DynamicPropertySource
         @JvmStatic
         fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") {
-                "${keycloak.authServerUrl}/realms/$REALM"
+            if (dockerAvailable) {
+                registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") {
+                    "${keycloak!!.authServerUrl}/realms/$REALM"
+                }
             }
         }
     }
@@ -152,7 +164,7 @@ class KeycloakScimProvisioningE2eTest {
         val keycloakUser = getKeycloakUser(keycloakUserId)
         keycloakUser.shouldNotBeNull()
 
-        // --- Step 3: Simulate SCIM extension — POST user to our SCIM server ---
+        // --- Step 3: Simulate SCIM extension -- POST user to our SCIM server ---
         val scimUser = mapKeycloakUserToScim(keycloakUser)
         val created = scimClient.create<User>("/Users", scimUser)
 
@@ -171,7 +183,7 @@ class KeycloakScimProvisioningE2eTest {
         )
         searchResult.statusCode shouldBe 200
 
-        // --- Step 5: Simulate SCIM extension — update propagation ---
+        // --- Step 5: Simulate SCIM extension -- update propagation ---
         // Update user in Keycloak
         updateKeycloakUser(keycloakUserId, firstName = "Janet", lastName = "Doe-Smith")
 
@@ -203,7 +215,7 @@ class KeycloakScimProvisioningE2eTest {
         afterUpdate.statusCode shouldBe 200
         afterUpdate.value.userName shouldBe keycloakUsername
 
-        // --- Step 6: Simulate SCIM extension — delete propagation ---
+        // --- Step 6: Simulate SCIM extension -- delete propagation ---
         // Delete user in Keycloak
         deleteKeycloakUser(keycloakUserId)
 
@@ -274,7 +286,7 @@ class KeycloakScimProvisioningE2eTest {
     // ---- Keycloak Admin REST API helpers ----
 
     private fun obtainServiceAccountToken(): String {
-        val tokenUrl = "${keycloak.authServerUrl}/realms/$REALM/protocol/openid-connect/token"
+        val tokenUrl = "${keycloak!!.authServerUrl}/realms/$REALM/protocol/openid-connect/token"
         val formData = listOf(
             "grant_type" to "client_credentials",
             "client_id" to CLIENT_ID,
@@ -298,12 +310,12 @@ class KeycloakScimProvisioningE2eTest {
     }
 
     private fun obtainAdminToken(): String {
-        val tokenUrl = "${keycloak.authServerUrl}/realms/master/protocol/openid-connect/token"
+        val tokenUrl = "${keycloak!!.authServerUrl}/realms/master/protocol/openid-connect/token"
         val formData = listOf(
             "grant_type" to "password",
             "client_id" to "admin-cli",
-            "username" to keycloak.adminUsername,
-            "password" to keycloak.adminPassword
+            "username" to keycloak!!.adminUsername,
+            "password" to keycloak!!.adminPassword
         ).joinToString("&") { (key, value) ->
             "${URLEncoder.encode(key, Charsets.UTF_8)}=${URLEncoder.encode(value, Charsets.UTF_8)}"
         }
@@ -329,7 +341,7 @@ class KeycloakScimProvisioningE2eTest {
         lastName: String
     ): String {
         val adminToken = obtainAdminToken()
-        val usersUrl = "${keycloak.authServerUrl}/admin/realms/$REALM/users"
+        val usersUrl = "${keycloak!!.authServerUrl}/admin/realms/$REALM/users"
 
         val userJson = objectMapper.writeValueAsString(
             mapOf(
@@ -361,7 +373,7 @@ class KeycloakScimProvisioningE2eTest {
 
     private fun getKeycloakUser(userId: String): JsonNode {
         val adminToken = obtainAdminToken()
-        val userUrl = "${keycloak.authServerUrl}/admin/realms/$REALM/users/$userId"
+        val userUrl = "${keycloak!!.authServerUrl}/admin/realms/$REALM/users/$userId"
 
         val request = HttpRequest.newBuilder()
             .uri(URI.create(userUrl))
@@ -379,7 +391,7 @@ class KeycloakScimProvisioningE2eTest {
 
     private fun updateKeycloakUser(userId: String, firstName: String, lastName: String) {
         val adminToken = obtainAdminToken()
-        val userUrl = "${keycloak.authServerUrl}/admin/realms/$REALM/users/$userId"
+        val userUrl = "${keycloak!!.authServerUrl}/admin/realms/$REALM/users/$userId"
 
         val updateJson = objectMapper.writeValueAsString(
             mapOf(
@@ -403,7 +415,7 @@ class KeycloakScimProvisioningE2eTest {
 
     private fun deleteKeycloakUser(userId: String) {
         val adminToken = obtainAdminToken()
-        val userUrl = "${keycloak.authServerUrl}/admin/realms/$REALM/users/$userId"
+        val userUrl = "${keycloak!!.authServerUrl}/admin/realms/$REALM/users/$userId"
 
         val request = HttpRequest.newBuilder()
             .uri(URI.create(userUrl))

--- a/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/repository/InMemoryResourceRepository.kt
+++ b/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/repository/InMemoryResourceRepository.kt
@@ -84,4 +84,21 @@ class InMemoryResourceRepository<T : ScimResource>(
     fun clear() = store.clear()
 
     fun getAll(): List<T> = store.values.toList()
+
+    fun createWithId(id: String, resource: T): T {
+        val now = Instant.now()
+        val meta = Meta(
+            resourceType = resource.schemas.firstOrNull()?.substringAfterLast(":"),
+            created = now,
+            lastModified = now,
+            version = ETag("W/\"${UUID.randomUUID()}\"")
+        )
+        val stored = copyWithIdAndMeta(resource, id, meta)
+        store[id] = stored
+        return stored
+    }
+
+    fun deleteIfExists(id: String) {
+        store.remove(id)
+    }
 }

--- a/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/contract/InMemoryScimApiContractTest.kt
+++ b/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/contract/InMemoryScimApiContractTest.kt
@@ -9,10 +9,12 @@ import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
 import com.marcosbarbero.scim2.server.config.ScimServerConfig
 import com.marcosbarbero.scim2.test.handler.InMemoryResourceHandler
 import com.marcosbarbero.scim2.test.repository.InMemoryResourceRepository
+import io.github.serpro69.kfaker.Faker
 
 class InMemoryScimApiContractTest : ScimApiContractTest() {
 
     private val objectMapper = JacksonScimSerializer.defaultObjectMapper()
+    private val faker = Faker()
 
     override fun createDispatcher(): ScimEndpointDispatcher {
         val userRepository = InMemoryResourceRepository<User> { user, id, meta ->
@@ -60,7 +62,7 @@ class InMemoryScimApiContractTest : ScimApiContractTest() {
         objectMapper.writeValueAsBytes(
             mapOf(
                 "schemas" to listOf("urn:ietf:params:scim:schemas:core:2.0:User"),
-                "userName" to "john.doe"
+                "userName" to faker.internet.email()
             )
         )
 }

--- a/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/pact/ScimProviderPactVerificationTest.kt
+++ b/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/pact/ScimProviderPactVerificationTest.kt
@@ -6,10 +6,26 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.marcosbarbero.scim2.core.domain.model.resource.Group
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.schema.introspector.SchemaRegistry
+import com.marcosbarbero.scim2.core.serialization.jackson.JacksonScimSerializer
+import com.marcosbarbero.scim2.server.adapter.discovery.DiscoveryService
+import com.marcosbarbero.scim2.server.adapter.http.ScimEndpointDispatcher
+import com.marcosbarbero.scim2.server.config.ScimServerConfig
+import com.marcosbarbero.scim2.server.http.HttpMethod
+import com.marcosbarbero.scim2.server.http.ScimHttpRequest
+import com.marcosbarbero.scim2.test.handler.InMemoryResourceHandler
+import com.marcosbarbero.scim2.test.repository.InMemoryResourceRepository
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIf
 import org.junit.jupiter.api.extension.ExtendWith
+import java.net.InetSocketAddress
+import java.net.URI
 
 /**
  * Pact Provider verification test.
@@ -18,21 +34,134 @@ import org.junit.jupiter.api.extension.ExtendWith
  * defined by the ScimClient consumer tests.
  *
  * The pact files are loaded from the client module's target/pacts directory.
- *
- * Note: This test requires an actual HTTP server to be started.
- * Wire up the JDK HttpServer with ScimEndpointDispatcher + InMemoryResourceHandler
- * (similar to sample-server-plain) in a @BeforeAll method to set the serverPort.
+ * This test is skipped when pact files do not exist (consumer tests must run first).
  */
-@Disabled("Provider verification requires in-memory SCIM server wiring -- see TODO in companion object")
 @Provider("ScimServiceProvider")
 @PactFolder("../../scim2-sdk-client/target/pacts")
+@EnabledIf("pactFilesExist")
 class ScimProviderPactVerificationTest {
 
     companion object {
-        // TODO: Start an in-memory SCIM server in @BeforeAll and assign the port here.
-        // Use the JDK HttpServer with ScimEndpointDispatcher + InMemoryResourceHandler
-        // (similar to sample-server-plain).
-        var serverPort: Int = 0
+        private var serverPort: Int = 0
+        private lateinit var httpServer: HttpServer
+        private lateinit var userRepository: InMemoryResourceRepository<User>
+        private lateinit var groupRepository: InMemoryResourceRepository<Group>
+        private lateinit var dispatcher: ScimEndpointDispatcher
+        private val serializer = JacksonScimSerializer()
+
+        @JvmStatic
+        fun pactFilesExist(): Boolean {
+            val pactDir = java.io.File("../../scim2-sdk-client/target/pacts")
+            // Also try from the module directory
+            val altPactDir = java.io.File(
+                System.getProperty("user.dir") + "/../../scim2-sdk-client/target/pacts"
+            )
+            return (pactDir.isDirectory && pactDir.listFiles()?.isNotEmpty() == true) ||
+                (altPactDir.isDirectory && altPactDir.listFiles()?.isNotEmpty() == true)
+        }
+
+        @BeforeAll
+        @JvmStatic
+        fun startServer() {
+            val config = ScimServerConfig()
+
+            userRepository = InMemoryResourceRepository { user, id, meta ->
+                user.copy(id = id, meta = meta)
+            }
+            groupRepository = InMemoryResourceRepository { group, id, meta ->
+                group.copy(id = id, meta = meta)
+            }
+
+            val userHandler = InMemoryResourceHandler(
+                resourceType = User::class.java,
+                endpoint = "/Users",
+                repository = userRepository
+            )
+            val groupHandler = InMemoryResourceHandler(
+                resourceType = Group::class.java,
+                endpoint = "/Groups",
+                repository = groupRepository
+            )
+
+            val schemaRegistry = SchemaRegistry().apply {
+                register(User::class)
+                register(Group::class)
+            }
+
+            val discoveryService = DiscoveryService(
+                handlers = listOf(userHandler, groupHandler),
+                schemaRegistry = schemaRegistry,
+                config = config
+            )
+
+            dispatcher = ScimEndpointDispatcher(
+                handlers = listOf(userHandler, groupHandler),
+                bulkHandler = null,
+                meHandler = null,
+                discoveryService = discoveryService,
+                config = config,
+                serializer = serializer
+            )
+
+            httpServer = HttpServer.create(InetSocketAddress(0), 0)
+            httpServer.createContext("/") { exchange -> handleRequest(exchange) }
+            httpServer.start()
+            serverPort = httpServer.address.port
+        }
+
+        @JvmStatic
+        fun stopServer() {
+            if (::httpServer.isInitialized) {
+                httpServer.stop(0)
+            }
+        }
+
+        private fun handleRequest(exchange: HttpExchange) {
+            try {
+                val uri = exchange.requestURI
+                val method = HttpMethod.valueOf(exchange.requestMethod.uppercase())
+                val headers = exchange.requestHeaders.mapValues { (_, values) -> values }
+                val queryParams = parseQueryParams(uri)
+                val body = exchange.requestBody.readBytes().takeIf { it.isNotEmpty() }
+
+                val scimRequest = ScimHttpRequest(
+                    method = method,
+                    path = uri.path,
+                    headers = headers,
+                    queryParameters = queryParams,
+                    body = body
+                )
+
+                val scimResponse = dispatcher.dispatch(scimRequest)
+
+                scimResponse.headers.forEach { (key, value) ->
+                    exchange.responseHeaders.add(key, value)
+                }
+
+                val responseBody = scimResponse.body
+                if (responseBody != null && responseBody.isNotEmpty()) {
+                    exchange.sendResponseHeaders(scimResponse.status, responseBody.size.toLong())
+                    exchange.responseBody.write(responseBody)
+                } else {
+                    exchange.sendResponseHeaders(scimResponse.status, -1)
+                }
+                exchange.close()
+            } catch (e: Exception) {
+                val errorBody = """{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"status":"500","detail":"${e.message}"}""".toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/scim+json")
+                exchange.sendResponseHeaders(500, errorBody.size.toLong())
+                exchange.responseBody.write(errorBody)
+                exchange.close()
+            }
+        }
+
+        private fun parseQueryParams(uri: URI): Map<String, List<String>> {
+            val query = uri.query ?: return emptyMap()
+            return query.split("&")
+                .map { it.split("=", limit = 2) }
+                .filter { it.size == 2 }
+                .groupBy({ it[0] }, { java.net.URLDecoder.decode(it[1], Charsets.UTF_8) })
+        }
     }
 
     @BeforeEach
@@ -42,22 +171,34 @@ class ScimProviderPactVerificationTest {
 
     @State("no users exist")
     fun noUsersExist() {
-        // Clear the in-memory store
+        userRepository.clear()
+        groupRepository.clear()
     }
 
     @State("a user with id 123 exists")
     fun userExists() {
-        // Create a user with id 123 in the in-memory store
+        userRepository.clear()
+        val user = User(userName = "pact.test.user")
+        val created = userRepository.create(user)
+        // The InMemoryResourceRepository assigns a UUID, but the pact expects id "123".
+        // We need to ensure the user can be fetched by its actual ID.
+        // The pact consumer uses stringValue("id", "123") for GET, meaning it expects exact match.
+        // We store with explicit id "123".
+        userRepository.clear()
+        userRepository.createWithId("123", user)
     }
 
     @State("no user with id 999 exists")
     fun userDoesNotExist() {
-        // Ensure no user with id 999
+        // Ensure no user with id 999 exists - clear to be safe
+        userRepository.deleteIfExists("999")
     }
 
     @State("users exist")
     fun usersExist() {
-        // Create some sample users
+        userRepository.clear()
+        userRepository.create(User(userName = "pact.user.1"))
+        userRepository.create(User(userName = "pact.user.2"))
     }
 
     @State("server is running")


### PR DESCRIPTION
Addresses all 12 pre-release findings: wires up Pact provider verification, adds CONTRIBUTING.md and CHANGELOG.md, adds Maven Central POM metadata (developers, SCM), configures JaCoCo 0.8.13 + Codecov, adds Dokka for Kotlin API docs, fixes Keycloak test Docker skip, documents EnterpriseUser extension, replaces hardcoded test values with kotlin-faker.