### PR TITLE
fix: CI failures — Byte Buddy Java 25 support and PostgreSQL version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,11 +299,17 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <argLine>-Dnet.bytebuddy.experimental=true ${argLine}</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven-failsafe-plugin.version}</version>
+                    <configuration>
+                        <argLine>-Dnet.bytebuddy.experimental=true ${argLine}</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -446,6 +452,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/PostgresCustomSchemaTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/PostgresCustomSchemaTest.kt
@@ -21,7 +21,7 @@ class PostgresCustomSchemaTest {
 
     companion object {
         @Container
-        val postgres = PostgreSQLContainer("postgres:17-alpine")
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
             .withInitScript("create-custom-schema.sql")
 
         @JvmStatic

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/PostgresIntegrationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/PostgresIntegrationTest.kt
@@ -26,7 +26,7 @@ class PostgresIntegrationTest {
 
     companion object {
         @Container
-        val postgres = PostgreSQLContainer("postgres:17-alpine")
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
 
         @JvmStatic
         @DynamicPropertySource


### PR DESCRIPTION
## Summary
- Add `-Dnet.bytebuddy.experimental=true` to `maven-surefire-plugin` and `maven-failsafe-plugin` `argLine` to support Java 25 with MockK/Byte Buddy
- Downgrade PostgreSQL Testcontainer image from `postgres:17-alpine` to `postgres:16-alpine` for Flyway community edition compatibility

## Test plan
- [x] `mvn clean verify -pl scim2-sdk-spring-boot-autoconfigure -am` passes (71 tests, 0 failures)
- [ ] CI pipeline passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)