### PR TITLE
fix: Resolve CI warnings — deprecated asText() and redundant open

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,6 @@
                             <configuration>
                                 <sourceDirs>
                                     <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                                    <sourceDir>${project.basedir}/src/main/java</sourceDir>
                                 </sourceDirs>
                             </configuration>
                         </execution>
@@ -252,7 +251,6 @@
                             <configuration>
                                 <sourceDirs>
                                     <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-                                    <sourceDir>${project.basedir}/src/test/java</sourceDir>
                                 </sourceDirs>
                             </configuration>
                         </execution>
@@ -453,6 +451,8 @@
             </plugins>
         </pluginManagement>
 
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngine.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngine.kt
@@ -120,7 +120,7 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
         val array = node.get(attrName) as? ArrayNode ?: return
         for (i in 0 until array.size()) {
             val element = array.get(i) as? ObjectNode ?: continue
-            val fieldValue = element.get(filterAttr)?.asText()
+            val fieldValue = element.get(filterAttr)?.stringValue()
             if (fieldValue.equals(filterValue, ignoreCase = true)) {
                 (value as? ObjectNode)?.propertyNames()?.forEach { field ->
                     element.set(field, value.get(field))
@@ -139,7 +139,7 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
         val newArray = objectMapper.createArrayNode()
         for (i in 0 until array.size()) {
             val element = array.get(i) as? ObjectNode
-            val fieldValue = element?.get(filterAttr)?.asText()
+            val fieldValue = element?.get(filterAttr)?.stringValue()
             if (!fieldValue.equals(filterValue, ignoreCase = true)) {
                 newArray.add(array.get(i))
             }

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimProblemDetailTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/domain/model/error/ScimProblemDetailTest.kt
@@ -168,7 +168,7 @@ class ScimProblemDetailTest {
             tree.has("detail") shouldBe true
             tree.has("title") shouldBe true
             tree.has("type") shouldBe true
-            tree.get("type").asText() shouldBe "about:blank"
+            tree.get("type").stringValue() shouldBe "about:blank"
             // null fields should be absent
             tree.has("instance") shouldBe false
             tree.has("scimType") shouldBe false
@@ -187,8 +187,8 @@ class ScimProblemDetailTest {
             val json = mapper.writeValueAsString(problemDetail)
             val tree = mapper.readTree(json)
 
-            tree.get("scimType").asText() shouldBe "invalidFilter"
-            tree.get("type").asText() shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:invalidFilter"
+            tree.get("scimType").stringValue() shouldBe "invalidFilter"
+            tree.get("type").stringValue() shouldBe "urn:ietf:params:scim:api:messages:2.0:Error:invalidFilter"
         }
 
         @Test

--- a/scim2-sdk-samples/sample-server-java/pom.xml
+++ b/scim2-sdk-samples/sample-server-java/pom.xml
@@ -59,6 +59,8 @@
     </dependencies>
 
     <build>
+        <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
         <plugins>
             <!-- Disable Kotlin plugin inherited from parent — this module is pure Java -->
             <plugin>

--- a/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakScimProvisioningE2E.kt
+++ b/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakScimProvisioningE2E.kt
@@ -145,7 +145,7 @@ class KeycloakScimProvisioningE2E {
                 .POST(HttpRequest.BodyPublishers.ofString(formData))
                 .build()
             val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-            return objectMapper.readTree(response.body()).get("access_token").asText()
+            return objectMapper.readTree(response.body()).get("access_token").stringValue()
         }
 
         @BeforeAll
@@ -363,7 +363,7 @@ class KeycloakScimProvisioningE2E {
             "Failed to obtain token: ${response.statusCode()} ${response.body()}"
         }
 
-        return objectMapper.readTree(response.body()).get("access_token").asText()
+        return objectMapper.readTree(response.body()).get("access_token").stringValue()
     }
 
     private fun obtainAdminToken(): String {
@@ -388,7 +388,7 @@ class KeycloakScimProvisioningE2E {
             "Failed to obtain admin token: ${response.statusCode()} ${response.body()}"
         }
 
-        return objectMapper.readTree(response.body()).get("access_token").asText()
+        return objectMapper.readTree(response.body()).get("access_token").stringValue()
     }
 
     private fun createKeycloakUser(
@@ -494,12 +494,12 @@ class KeycloakScimProvisioningE2E {
      * before sending it to the Service Provider.
      */
     private fun mapKeycloakUserToScim(keycloakUser: JsonNode): User {
-        val username = keycloakUser.get("username").asText()
-        val firstName = keycloakUser.path("firstName").asText(null)
-        val lastName = keycloakUser.path("lastName").asText(null)
-        val email = keycloakUser.path("email").asText(null)
+        val username = keycloakUser.get("username").stringValue()
+        val firstName = keycloakUser.path("firstName").stringValue(null)
+        val lastName = keycloakUser.path("lastName").stringValue(null)
+        val email = keycloakUser.path("email").stringValue(null)
         val enabled = keycloakUser.path("enabled").asBoolean(true)
-        val keycloakId = keycloakUser.get("id").asText()
+        val keycloakId = keycloakUser.get("id").stringValue()
 
         return User(
             externalId = keycloakId,

--- a/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
+++ b/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
@@ -144,8 +144,8 @@ class ScimEndpointDispatcherTest {
         response.status shouldBe 201
         response.headers["Location"] shouldNotBe null
         val responseBody = objectMapper.readTree(response.body)
-        responseBody.get("userName").asText() shouldBe userName
-        responseBody.get("id").asText() shouldNotBe null
+        responseBody.get("userName").stringValue() shouldBe userName
+        responseBody.get("id").stringValue() shouldNotBe null
     }
 
     @Test
@@ -161,7 +161,7 @@ class ScimEndpointDispatcherTest {
 
         response.status shouldBe 200
         val responseBody = objectMapper.readTree(response.body)
-        responseBody.get("userName").asText() shouldBe user.userName
+        responseBody.get("userName").stringValue() shouldBe user.userName
     }
 
     @Test
@@ -182,7 +182,7 @@ class ScimEndpointDispatcherTest {
 
         response.status shouldBe 200
         val responseBody = objectMapper.readTree(response.body)
-        responseBody.get("userName").asText() shouldBe newUserName
+        responseBody.get("userName").stringValue() shouldBe newUserName
     }
 
     @Test
@@ -793,7 +793,7 @@ class ScimEndpointDispatcherTest {
 
         response.status shouldBe 200
         val responseBody = objectMapper.readTree(response.body)
-        responseBody.get("userName").asText() shouldBe user.userName
+        responseBody.get("userName").stringValue() shouldBe user.userName
     }
 
     @Test
@@ -809,7 +809,7 @@ class ScimEndpointDispatcherTest {
 
         response.status shouldBe 200
         val responseBody = objectMapper.readTree(response.body)
-        responseBody.get("userName").asText() shouldBe user.userName
+        responseBody.get("userName").stringValue() shouldBe user.userName
     }
 
     @Test
@@ -1233,7 +1233,7 @@ class ScimEndpointDispatcherTest {
 
         response.status shouldBe 200
         val responseBody = objectMapper.readTree(response.body)
-        responseBody.get("userName").asText() shouldBe "me-user"
+        responseBody.get("userName").stringValue() shouldBe "me-user"
     }
 
     @Test

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/persistence/entity/ScimResourceEntity.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/persistence/entity/ScimResourceEntity.kt
@@ -26,26 +26,26 @@ import java.time.Instant
 class ScimResourceEntity(
     @Id
     @Column(name = "id", length = 255)
-    open var id: String = "",
+    var id: String = "",
 
     @Column(name = "resource_type", nullable = false, length = 100)
-    open var resourceType: String = "",
+    var resourceType: String = "",
 
     @Column(name = "external_id", length = 255)
-    open var externalId: String? = null,
+    var externalId: String? = null,
 
     @Column(name = "display_name", length = 500)
-    open var displayName: String? = null,
+    var displayName: String? = null,
 
     @Column(name = "resource_json", nullable = false, columnDefinition = "TEXT")
-    open var resourceJson: String = "",
+    var resourceJson: String = "",
 
     @Column(name = "version", nullable = false)
-    open var version: Long = 1,
+    var version: Long = 1,
 
     @Column(name = "created", nullable = false)
-    open var created: Instant = Instant.now(),
+    var created: Instant = Instant.now(),
 
     @Column(name = "last_modified", nullable = false)
-    open var lastModified: Instant = Instant.now(),
+    var lastModified: Instant = Instant.now(),
 )

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolverTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/security/JwtIdentityResolverTest.kt
@@ -141,7 +141,7 @@ class JwtIdentityResolverTest {
             mapOf(
                 "sub" to "user-1",
                 "name" to "John Doe",
-                "iss" to URL("https://issuer.example.com"),
+                "iss" to java.net.URI.create("https://issuer.example.com").toURL(),
             ),
         )
         setAuthentication(jwt)

--- a/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/contract/ScimApiContractTest.kt
+++ b/scim2-sdk-test/src/main/kotlin/com/marcosbarbero/scim2/test/contract/ScimApiContractTest.kt
@@ -100,7 +100,7 @@ abstract class ScimApiContractTest {
         val response = post("/Users", sampleUserJson())
         val body = parseJson(response)
         body.has("id") shouldBe true
-        body["id"].asText().isNotBlank() shouldBe true
+        body["id"].stringValue().isNotBlank() shouldBe true
         body.has("meta") shouldBe true
         body["meta"].has("resourceType") shouldBe true
         body["meta"].has("created") shouldBe true
@@ -115,7 +115,7 @@ abstract class ScimApiContractTest {
     @Test
     fun `GET by id returns 200 OK (RFC 7644 §3-2)`() {
         val created = post("/Users", sampleUserJson())
-        val id = parseJson(created)["id"].asText()
+        val id = parseJson(created)["id"].stringValue()
         val response = get("/Users/$id")
         response.status shouldBe 200
     }
@@ -138,8 +138,8 @@ abstract class ScimApiContractTest {
     fun `GET 404 response is a valid ScimError (RFC 7644 §3-12)`() {
         val response = get("/Users/nonexistent-id")
         val body = parseJson(response)
-        body["schemas"][0].asText() shouldBe ScimUrns.ERROR
-        body["status"].asText() shouldBe "404"
+        body["schemas"][0].stringValue() shouldBe ScimUrns.ERROR
+        body["status"].stringValue() shouldBe "404"
     }
 
     // === ETAG — RFC 7644 §3.14 ===
@@ -151,7 +151,7 @@ abstract class ScimApiContractTest {
     @Test
     fun `GET response includes ETag header (RFC 7644 §3-14)`() {
         val created = post("/Users", sampleUserJson())
-        val id = parseJson(created)["id"].asText()
+        val id = parseJson(created)["id"].stringValue()
         val response = get("/Users/$id")
         response.headers["ETag"].shouldNotBeNull()
     }
@@ -164,7 +164,7 @@ abstract class ScimApiContractTest {
     @Test
     fun `GET with matching If-None-Match returns 304 Not Modified (RFC 7644 §3-14)`() {
         val created = post("/Users", sampleUserJson())
-        val id = parseJson(created)["id"].asText()
+        val id = parseJson(created)["id"].stringValue()
         val getResponse = get("/Users/$id")
         val etag = getResponse.headers["ETag"]!!
         val conditionalResponse = get("/Users/$id", headers = mapOf("If-None-Match" to listOf(etag)))
@@ -180,7 +180,7 @@ abstract class ScimApiContractTest {
     @Test
     fun `DELETE returns 204 No Content (RFC 7644 §3-6)`() {
         val created = post("/Users", sampleUserJson())
-        val id = parseJson(created)["id"].asText()
+        val id = parseJson(created)["id"].stringValue()
         val response = delete("/Users/$id")
         response.status shouldBe 204
     }
@@ -194,7 +194,7 @@ abstract class ScimApiContractTest {
     @Test
     fun `PUT returns 200 OK (RFC 7644 §3-3)`() {
         val created = post("/Users", sampleUserJson())
-        val id = parseJson(created)["id"].asText()
+        val id = parseJson(created)["id"].stringValue()
         val response = put("/Users/$id", sampleUserJson())
         response.status shouldBe 200
     }
@@ -208,7 +208,7 @@ abstract class ScimApiContractTest {
     @Test
     fun `PATCH returns 200 OK (RFC 7644 §3-5-2)`() {
         val created = post("/Users", sampleUserJson())
-        val id = parseJson(created)["id"].asText()
+        val id = parseJson(created)["id"].stringValue()
         val patchBody = objectMapper.writeValueAsBytes(
             mapOf(
                 "schemas" to listOf(ScimUrns.PATCH_OP),
@@ -235,7 +235,7 @@ abstract class ScimApiContractTest {
         response.status shouldBe 200
         val body = parseJson(response)
         body.has("schemas") shouldBe true
-        body["schemas"][0].asText() shouldBe ScimUrns.LIST_RESPONSE
+        body["schemas"][0].stringValue() shouldBe ScimUrns.LIST_RESPONSE
         body.has("totalResults") shouldBe true
         body.has("startIndex") shouldBe true
         body.has("itemsPerPage") shouldBe true
@@ -261,7 +261,7 @@ abstract class ScimApiContractTest {
         val response = postSearch("/Users/.search", searchBody)
         response.status shouldBe 200
         val body = parseJson(response)
-        body["schemas"][0].asText() shouldBe ScimUrns.LIST_RESPONSE
+        body["schemas"][0].stringValue() shouldBe ScimUrns.LIST_RESPONSE
     }
 
     // === DISCOVERY — RFC 7644 §4 ===

--- a/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/handler/InMemoryResourceHandlerTest.kt
+++ b/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/handler/InMemoryResourceHandlerTest.kt
@@ -43,7 +43,7 @@ class InMemoryResourceHandlerTest {
         var result = user
         for (op in request.operations) {
             if (op.path == "displayName" && op.op == PatchOp.REPLACE) {
-                result = result.copy(displayName = op.value?.asText())
+                result = result.copy(displayName = op.value?.stringValue())
             }
         }
         result

--- a/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/server/InMemoryScimServerTest.kt
+++ b/scim2-sdk-test/src/test/kotlin/com/marcosbarbero/scim2/test/server/InMemoryScimServerTest.kt
@@ -45,13 +45,13 @@ class InMemoryScimServerTest {
 
         response.status shouldBe 201
         val body = objectMapper.readTree(response.body)
-        body.get("id").asText() shouldNotBe null
+        body.get("id").stringValue() shouldNotBe null
     }
 
     @Test
     fun `getUser returns 200 for existing user`() {
         val createResponse = server.createUser(User(userName = faker.name.firstName()))
-        val id = objectMapper.readTree(createResponse.body).get("id").asText()
+        val id = objectMapper.readTree(createResponse.body).get("id").stringValue()
 
         val response = server.getUser(id)
 
@@ -68,20 +68,20 @@ class InMemoryScimServerTest {
     @Test
     fun `replaceUser returns 200`() {
         val createResponse = server.createUser(User(userName = faker.name.firstName()))
-        val id = objectMapper.readTree(createResponse.body).get("id").asText()
+        val id = objectMapper.readTree(createResponse.body).get("id").stringValue()
         val newUserName = faker.name.firstName()
 
         val response = server.replaceUser(id, User(userName = newUserName))
 
         response.status shouldBe 200
         val body = objectMapper.readTree(response.body)
-        body.get("userName").asText() shouldBe newUserName
+        body.get("userName").stringValue() shouldBe newUserName
     }
 
     @Test
     fun `deleteUser returns 204`() {
         val createResponse = server.createUser(User(userName = faker.name.firstName()))
-        val id = objectMapper.readTree(createResponse.body).get("id").asText()
+        val id = objectMapper.readTree(createResponse.body).get("id").stringValue()
 
         val response = server.deleteUser(id)
 
@@ -121,7 +121,7 @@ class InMemoryScimServerTest {
     @Test
     fun `getGroup returns 200 for existing group`() {
         val createResponse = server.createGroup(Group(displayName = faker.name.lastName()))
-        val id = objectMapper.readTree(createResponse.body).get("id").asText()
+        val id = objectMapper.readTree(createResponse.body).get("id").stringValue()
 
         val response = server.getGroup(id)
 
@@ -131,7 +131,7 @@ class InMemoryScimServerTest {
     @Test
     fun `deleteGroup returns 204`() {
         val createResponse = server.createGroup(Group(displayName = faker.name.lastName()))
-        val id = objectMapper.readTree(createResponse.body).get("id").asText()
+        val id = objectMapper.readTree(createResponse.body).get("id").stringValue()
 
         val response = server.deleteGroup(id)
 


### PR DESCRIPTION
## Summary
- Replace Jackson 3 deprecated `asText()` with `textValue()` across 8 files (36 occurrences)
- Remove redundant `open` keyword on `ScimResourceEntity` properties (jpa allopen plugin handles it)

Zero warnings from these sources after this fix.