### PR TITLE
fix: Use correct Dokka 2.0.0 Maven goal name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
                         <execution>
                             <phase>package</phase>
                             <goals>
-                                <goal>dokkaJavadoc</goal>
+                                <goal>javadoc</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
## Summary
- Fix CI failure caused by using the removed `dokkaJavadoc` goal name in dokka-maven-plugin 2.0.0
- The goal was renamed to `javadoc` in Dokka 2.0.0

## Test plan
- [ ] CI build passes with the updated goal name

🤖 Generated with [Claude Code](https://claude.com/claude-code)