### PR TITLE
fix: Upgrade dokka-maven-plugin to 2.1.0 and fix goal name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
                 <plugin>
                     <groupId>org.jetbrains.dokka</groupId>
                     <artifactId>dokka-maven-plugin</artifactId>
-                    <version>2.0.0</version>
+                    <version>2.1.0</version>
                     <executions>
                         <execution>
                             <phase>package</phase>


### PR DESCRIPTION
## Summary
- Rename `dokkaJavadoc` goal to `javadoc` (renamed in Dokka 2.0+)
- Upgrade dokka-maven-plugin from 2.0.0 to 2.1.0 for Java 25 support

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)