### PR TITLE
fix: Skip Central publishing for sample modules

### DIFF
--- a/scim2-sdk-samples/sample-server-java/pom.xml
+++ b/scim2-sdk-samples/sample-server-java/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skipPublishing>true</central.publishing.skipPublishing>
         <jacoco.skip>true</jacoco.skip>
         <maven.install.skip>true</maven.install.skip>
     </properties>

--- a/scim2-sdk-samples/sample-server-plain/pom.xml
+++ b/scim2-sdk-samples/sample-server-plain/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skipPublishing>true</central.publishing.skipPublishing>
         <jacoco.skip>true</jacoco.skip>
         <maven.install.skip>true</maven.install.skip>
     </properties>

--- a/scim2-sdk-samples/sample-server-spring/pom.xml
+++ b/scim2-sdk-samples/sample-server-spring/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <central.publishing.skipPublishing>true</central.publishing.skipPublishing>
         <jacoco.skip>true</jacoco.skip>
         <maven.install.skip>true</maven.install.skip>
     </properties>


### PR DESCRIPTION
## Summary
- Add `central.publishing.skipPublishing=true` to all sample modules
- The `central-publishing-maven-plugin` ignores `maven.deploy.skip` since it replaces the deploy lifecycle, so a separate property is needed

## Test plan
- [ ] CI release workflow no longer attempts to upload sample artifacts to Maven Central

🤖 Generated with [Claude Code](https://claude.com/claude-code)