### PR TITLE
feat: Auto-publish to Maven Central and automate semver releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,57 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
-  release:
-    types: [published]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  release:
-    name: Release to Maven Central
+  # Automatically create a semver tag based on conventional commits
+  tag:
+    name: Determine version and tag
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      new_version: ${{ steps.tag_version.outputs.new_version }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          tag_prefix: v
+          release_branches: main
+
+  # Create a GitHub Release from the new tag
+  github-release:
+    name: Create GitHub Release
+    needs: tag
+    if: needs.tag.outputs.new_tag != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.tag.outputs.new_tag }}
+          name: ${{ needs.tag.outputs.new_version }}
+          body: ${{ needs.tag.outputs.changelog }}
+          generate_release_notes: false
+
+  # Publish to Maven Central when a version tag is pushed
+  publish:
+    name: Publish to Maven Central
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,14 +76,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set release version from tag
+      - name: Extract version from tag
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-          else
-            VERSION="${GITHUB_REF#refs/tags/}"
-          fi
-          VERSION="${VERSION#v}"
+          VERSION="${GITHUB_REF#refs/tags/v}"
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Build, test, and deploy

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -53,54 +53,55 @@ The CI workflow uses these secrets automatically. For local releases, configure 
 
 ## Release Process
 
-### 1. Prepare the release
+Releases are fully automated via [Conventional Commits](https://www.conventionalcommits.org/) and semantic versioning.
 
-```bash
-# Ensure main is up to date
-git checkout main && git pull
+### How it works
 
-# Verify the build
-mvn clean verify -B
+1. Every push to `main` triggers the `release.yml` workflow
+2. The workflow analyzes commit messages since the last tag using [github-tag-action](https://github.com/mathieudutour/github-tag-action)
+3. It determines the version bump type based on conventional commit prefixes:
+   - `fix:` → **patch** bump (e.g., 1.0.0 → 1.0.1)
+   - `feat:` → **minor** bump (e.g., 1.0.0 → 1.1.0)
+   - `feat!:` or `BREAKING CHANGE:` → **major** bump (e.g., 1.0.0 → 2.0.0)
+4. A new `v*` tag and GitHub Release are created automatically
+5. The tag push triggers the publish job, which builds, signs, and deploys to Maven Central
+6. The `central-publishing-maven-plugin` auto-publishes and waits until artifacts are live
 
-# Run mutation tests
-mvn verify -Pmutation -pl scim2-sdk-core -B
-```
+### Manual release (if needed)
 
-### 2. Create a release
+You can still create a release manually:
 
-#### Option A: Release via GitHub UI (Recommended)
+#### Option A: Release via GitHub UI
 
 1. Go to the repository -> Releases -> "Create a new release"
-2. Create a new tag (e.g., `v1.0.0-M1`)
+2. Create a new tag (e.g., `v1.0.0`)
 3. Add release title and notes
 4. Click "Publish release"
-5. GitHub Actions automatically builds, tests, signs, and deploys to Maven Central
 
 #### Option B: Release via command line
 
 ```bash
-# Create and push a tag
-git tag v1.0.0-M1
-git push origin v1.0.0-M1
-
-# Then create GitHub Release
-gh release create v1.0.0-M1 --title "1.0.0-M1" --generate-notes
+git tag v1.0.0
+git push origin v1.0.0
 ```
 
-### 3. GitHub Actions handles the rest
+### Commit message conventions
 
-The `release.yml` workflow triggers on `v*` tags and GitHub Release publication:
-1. Builds all modules
-2. Runs all tests
-3. Signs artifacts with GPG
-4. Deploys to Sonatype Central Portal
-5. The artifacts are automatically published to Maven Central
+Follow [Conventional Commits](https://www.conventionalcommits.org/) to control versioning:
+
+```
+fix: resolve null pointer in ScimUser parser        → patch
+feat: add bulk operations support                   → minor
+feat!: redesign ResourceHandler SPI                 → major
+refactor: simplify filter parsing                   → patch (default bump)
+docs: update API documentation                      → patch (default bump)
+```
 
 ## Version Management
 
 The project uses `${revision}` with `flatten-maven-plugin` for CI-friendly versioning:
 - Development: `0.1.0-SNAPSHOT` (set in parent pom.xml)
-- Release: version from tag, passed as `-Drevision=1.0.0-M1`
+- Release: version derived automatically from conventional commits, passed as `-Drevision=X.Y.Z`
 
 ## Checklist for 1.0.0-M1
 

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,8 @@
                     <extensions>true</extensions>
                     <configuration>
                         <publishingServerId>central</publishingServerId>
+                        <autoPublish>true</autoPublish>
+                        <waitUntil>published</waitUntil>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## Summary
- Add `autoPublish=true` and `waitUntil=published` to `central-publishing-maven-plugin` so artifacts are published automatically (fixes the invisible deployment issue)
- Automate version management using conventional commits with `mathieudutour/github-tag-action`
- On every push to `main`: commits are analyzed, a semver tag is created, and a GitHub Release is published
- The new tag triggers the publish job which builds, signs, and deploys to Maven Central
- Update `docs/release-guide.md` to document the new automated flow

## How it works
1. `fix:` commits → patch bump
2. `feat:` commits → minor bump  
3. `feat!:` or `BREAKING CHANGE:` → major bump
4. Tag creation triggers Maven Central publish with auto-publish enabled

## Test plan
- [ ] CI passes
- [ ] Merge to main creates a new semver tag automatically
- [ ] Tag triggers publish job which deploys and auto-publishes to Maven Central

🤖 Generated with [Claude Code](https://claude.com/claude-code)