### PR TITLE
fix: Chain publish job after tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 permissions:
   contents: write
@@ -14,7 +12,6 @@ jobs:
   # Automatically create a semver tag based on conventional commits
   tag:
     name: Determine version and tag
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
@@ -49,10 +46,11 @@ jobs:
           body: ${{ needs.tag.outputs.changelog }}
           generate_release_notes: false
 
-  # Publish to Maven Central when a version tag is pushed
+  # Publish to Maven Central
   publish:
     name: Publish to Maven Central
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [tag, github-release]
+    if: needs.tag.outputs.new_version != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -76,13 +74,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Extract version from tag
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
-
       - name: Build, test, and deploy
-        run: mvn clean deploy -Prelease -Drevision=${{ env.RELEASE_VERSION }} -B
+        run: mvn clean deploy -Prelease -Drevision=${{ needs.tag.outputs.new_version }} -B
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
## Summary
- Fix publish job being skipped: GitHub Actions does not trigger workflows from tags created by `GITHUB_TOKEN` (anti-recursion protection)
- Chain the `publish` job after `tag` → `github-release` in the same workflow run
- Use `needs.tag.outputs.new_version` for the Maven revision instead of extracting from `github.ref`
- Remove the `tags: v*` trigger since it's no longer needed

## Test plan
- [ ] CI passes
- [ ] On merge to main: tag → github-release → publish all run sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)