### PR TITLE
fix: Generate javadoc JARs and exclude samples from Central bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
                         <execution>
                             <phase>package</phase>
                             <goals>
-                                <goal>javadoc</goal>
+                                <goal>javadocJar</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -448,6 +448,11 @@
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>true</autoPublish>
                         <waitUntil>published</waitUntil>
+                        <excludeArtifacts>
+                            <excludeArtifact>sample-server-plain</excludeArtifact>
+                            <excludeArtifact>sample-server-java</excludeArtifact>
+                            <excludeArtifact>sample-server-spring</excludeArtifact>
+                        </excludeArtifacts>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## Summary
- Change dokka-maven-plugin goal from `javadoc` to `javadocJar` — Maven Central requires a `-javadoc.jar` artifact for each module
- Add `excludeArtifacts` to `central-publishing-maven-plugin` to exclude sample modules from the Central bundle (they were being included and failing validation)

## Test plan
- [ ] CI passes
- [ ] On merge: publish job succeeds with javadoc JARs present and no sample modules in the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)