### PR TITLE
feat: Add outbound provisioning via Spring events and ScimClient

### DIFF
--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProperties.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProperties.kt
@@ -30,6 +30,7 @@ data class ScimProperties(
     val client: ClientProperties = ClientProperties(),
     val persistence: PersistenceProperties = PersistenceProperties(),
     val idp: IdpProperties = IdpProperties(),
+    val provisioning: ProvisioningProperties = ProvisioningProperties(),
 ) {
     data class IdpProperties(
         val provider: String? = null,
@@ -85,6 +86,12 @@ data class ScimProperties(
         val baseUrl: String? = null,
         val connectTimeout: java.time.Duration = java.time.Duration.ofSeconds(10),
         val readTimeout: java.time.Duration = java.time.Duration.ofSeconds(30),
+    )
+
+    data class ProvisioningProperties(
+        val enabled: Boolean = false,
+        val targetUrl: String? = null,
+        val bearerToken: String? = null,
     )
 
     data class PersistenceProperties(

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProvisioningAutoConfiguration.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProvisioningAutoConfiguration.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Marcos Barbero
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.client.adapter.httpclient.HttpClientTransport
+import com.marcosbarbero.scim2.client.api.ScimClient
+import com.marcosbarbero.scim2.client.api.ScimClientBuilder
+import com.marcosbarbero.scim2.client.port.BearerTokenAuthentication
+import com.marcosbarbero.scim2.core.event.ScimEventPublisher
+import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
+import com.marcosbarbero.scim2.server.port.ResourceHandler
+import com.marcosbarbero.scim2.spring.event.SpringScimEventPublisher
+import com.marcosbarbero.scim2.spring.provisioning.ScimProvisioningEventListener
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration(after = [ScimServerAutoConfiguration::class, ScimJacksonAutoConfiguration::class])
+@EnableConfigurationProperties(ScimProperties::class)
+class ScimProvisioningAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ScimEventPublisher::class)
+    fun springScimEventPublisher(applicationEventPublisher: ApplicationEventPublisher): ScimEventPublisher =
+        SpringScimEventPublisher(applicationEventPublisher)
+
+    @Bean
+    @ConditionalOnProperty(prefix = "scim.provisioning", name = ["enabled"], havingValue = "true")
+    @ConditionalOnClass(ScimClient::class)
+    fun scimProvisioningClient(
+        serializer: ScimSerializer,
+        properties: ScimProperties,
+    ): ScimClient {
+        val provisioningProps = properties.provisioning
+        val targetUrl = requireNotNull(provisioningProps.targetUrl) {
+            "scim.provisioning.target-url must be set when scim.provisioning.enabled=true"
+        }
+        val builder = ScimClientBuilder()
+            .baseUrl(targetUrl)
+            .transport(HttpClientTransport(java.net.http.HttpClient.newHttpClient(), properties.client.readTimeout))
+            .serializer(serializer)
+
+        provisioningProps.bearerToken?.let {
+            builder.authentication(BearerTokenAuthentication(it))
+        }
+
+        return builder.build()
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "scim.provisioning", name = ["enabled"], havingValue = "true")
+    fun scimProvisioningEventListener(
+        scimProvisioningClient: ScimClient,
+        handlers: ObjectProvider<ResourceHandler<*>>,
+    ): ScimProvisioningEventListener = ScimProvisioningEventListener(
+        client = scimProvisioningClient,
+        handlers = handlers.orderedStream().toList(),
+    )
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/event/SpringScimEventPublisher.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/event/SpringScimEventPublisher.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Marcos Barbero
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marcosbarbero.scim2.spring.event
+
+import com.marcosbarbero.scim2.core.event.ScimEvent
+import com.marcosbarbero.scim2.core.event.ScimEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * Bridges SCIM SDK events to Spring's ApplicationEvent system.
+ * Enables @EventListener methods to react to SCIM resource mutations.
+ */
+internal class SpringScimEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : ScimEventPublisher {
+    override fun publish(event: ScimEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/provisioning/ScimProvisioningEventListener.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/provisioning/ScimProvisioningEventListener.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Marcos Barbero
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marcosbarbero.scim2.spring.provisioning
+
+import com.marcosbarbero.scim2.client.api.ScimClient
+import com.marcosbarbero.scim2.core.event.ResourceCreatedEvent
+import com.marcosbarbero.scim2.core.event.ResourceDeletedEvent
+import com.marcosbarbero.scim2.core.event.ResourcePatchedEvent
+import com.marcosbarbero.scim2.core.event.ResourceReplacedEvent
+import com.marcosbarbero.scim2.core.event.ScimEvent
+import com.marcosbarbero.scim2.server.port.ResourceHandler
+import com.marcosbarbero.scim2.server.port.ScimRequestContext
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+
+/**
+ * Listens for SCIM resource mutation events and provisions them to a remote
+ * SCIM server via [ScimClient]. This enables outbound IdP provisioning —
+ * when a resource is created/updated/deleted locally, the change is pushed
+ * to the configured target.
+ */
+internal class ScimProvisioningEventListener(
+    private val client: ScimClient,
+    private val handlers: List<ResourceHandler<*>>,
+) {
+    private val log = LoggerFactory.getLogger(ScimProvisioningEventListener::class.java)
+
+    @EventListener
+    fun onScimEvent(event: ScimEvent) {
+        try {
+            when (event) {
+                is ResourceCreatedEvent -> handleCreated(event)
+                is ResourceReplacedEvent -> handleReplaced(event)
+                is ResourcePatchedEvent -> handleReplaced(event)
+                is ResourceDeletedEvent -> handleDeleted(event)
+                else -> log.debug("Ignoring event: {}", event::class.simpleName)
+            }
+        } catch (e: Exception) {
+            log.error("Failed to provision {} {} to target: {}", event.resourceType, event.resourceId, e.message, e)
+        }
+    }
+
+    private fun handleCreated(event: ResourceCreatedEvent) {
+        val handler = findHandler(event.resourceType) ?: return
+        val resource = handler.get(event.resourceId, provisioningContext())
+        val endpoint = handler.endpoint
+        log.info("Provisioning CREATE {} {} to target", event.resourceType, event.resourceId)
+        client.create(endpoint, resource, handler.resourceType.kotlin)
+    }
+
+    private fun handleReplaced(event: ScimEvent) {
+        val handler = findHandler(event.resourceType) ?: return
+        val resource = handler.get(event.resourceId, provisioningContext())
+        val endpoint = handler.endpoint
+        log.info("Provisioning REPLACE {} {} to target", event.resourceType, event.resourceId)
+        client.replace(endpoint, event.resourceId, resource, handler.resourceType.kotlin)
+    }
+
+    private fun handleDeleted(event: ResourceDeletedEvent) {
+        val handler = findHandler(event.resourceType) ?: return
+        log.info("Provisioning DELETE {} {} to target", event.resourceType, event.resourceId)
+        client.delete(handler.endpoint, event.resourceId)
+    }
+
+    private fun findHandler(resourceType: String): ResourceHandler<*>? {
+        val handler = handlers.firstOrNull { it.resourceType.simpleName == resourceType }
+        if (handler == null) {
+            log.warn("No handler found for resource type: {}", resourceType)
+        }
+        return handler
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : com.marcosbarbero.scim2.core.domain.model.resource.ScimResource> ResourceHandler<*>.get(
+        id: String,
+        context: ScimRequestContext,
+    ): T = (this as ResourceHandler<T>).get(id, context)
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : com.marcosbarbero.scim2.core.domain.model.resource.ScimResource> ScimClient.create(
+        endpoint: String,
+        resource: T,
+        type: kotlin.reflect.KClass<*>,
+    ) {
+        @Suppress("UNCHECKED_CAST")
+        create(endpoint, resource, type as kotlin.reflect.KClass<T>)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : com.marcosbarbero.scim2.core.domain.model.resource.ScimResource> ScimClient.replace(
+        endpoint: String,
+        id: String,
+        resource: T,
+        type: kotlin.reflect.KClass<*>,
+    ) {
+        @Suppress("UNCHECKED_CAST")
+        replace(endpoint, id, resource, type as kotlin.reflect.KClass<T>)
+    }
+
+    private fun provisioningContext(): ScimRequestContext = ScimRequestContext(
+        principalId = "scim-provisioning",
+        roles = setOf("admin"),
+    )
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -6,3 +6,4 @@ com.marcosbarbero.scim2.spring.autoconfigure.ScimObservabilityAutoConfiguration
 com.marcosbarbero.scim2.spring.autoconfigure.ScimPersistenceAutoConfiguration
 com.marcosbarbero.scim2.spring.autoconfigure.ScimFlywayAutoConfiguration
 com.marcosbarbero.scim2.spring.autoconfigure.ScimIdentityAutoConfiguration
+com.marcosbarbero.scim2.spring.autoconfigure.ScimProvisioningAutoConfiguration

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProvisioningAutoConfigurationTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/autoconfigure/ScimProvisioningAutoConfigurationTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Marcos Barbero
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marcosbarbero.scim2.spring.autoconfigure
+
+import com.marcosbarbero.scim2.core.event.ScimEventPublisher
+import com.marcosbarbero.scim2.spring.event.SpringScimEventPublisher
+import com.marcosbarbero.scim2.spring.provisioning.ScimProvisioningEventListener
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class ScimProvisioningAutoConfigurationTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                ScimProvisioningAutoConfiguration::class.java,
+            ),
+        )
+
+    @Test
+    fun `should register SpringScimEventPublisher as default`() {
+        contextRunner.run { context ->
+            context.containsBean("springScimEventPublisher") shouldBe true
+            context.getBean(ScimEventPublisher::class.java).shouldBeInstanceOf<SpringScimEventPublisher>()
+        }
+    }
+
+    @Test
+    fun `should not register SpringScimEventPublisher when custom publisher exists`() {
+        contextRunner
+            .withBean(ScimEventPublisher::class.java, { com.marcosbarbero.scim2.core.event.NoOpEventPublisher })
+            .run { context ->
+                context.containsBean("springScimEventPublisher") shouldBe false
+            }
+    }
+
+    @Test
+    fun `should not register provisioning listener when not enabled`() {
+        contextRunner.run { context ->
+            context.containsBean("scimProvisioningEventListener") shouldBe false
+        }
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/event/SpringScimEventPublisherTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/event/SpringScimEventPublisherTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Marcos Barbero
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marcosbarbero.scim2.spring.event
+
+import com.marcosbarbero.scim2.core.event.ResourceCreatedEvent
+import com.marcosbarbero.scim2.core.event.ResourceDeletedEvent
+import com.marcosbarbero.scim2.core.event.ScimEvent
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+
+class SpringScimEventPublisherTest {
+
+    @Test
+    fun `should publish ScimEvent as Spring ApplicationEvent`() {
+        val captured = slot<Any>()
+        val appPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+        val publisher = SpringScimEventPublisher(appPublisher)
+
+        val event = ResourceCreatedEvent(resourceType = "User", resourceId = "123")
+        publisher.publish(event)
+
+        verify { appPublisher.publishEvent(capture(captured)) }
+        (captured.captured as ScimEvent).resourceId shouldBe "123"
+    }
+
+    @Test
+    fun `should publish different event types`() {
+        val appPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+        val publisher = SpringScimEventPublisher(appPublisher)
+
+        publisher.publish(ResourceCreatedEvent(resourceType = "User", resourceId = "1"))
+        publisher.publish(ResourceDeletedEvent(resourceType = "Group", resourceId = "2"))
+
+        verify(exactly = 2) { appPublisher.publishEvent(any()) }
+    }
+}

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/provisioning/ScimProvisioningEventListenerTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/provisioning/ScimProvisioningEventListenerTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Marcos Barbero
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marcosbarbero.scim2.spring.provisioning
+
+import com.marcosbarbero.scim2.client.api.ScimClient
+import com.marcosbarbero.scim2.client.api.ScimResponse
+import com.marcosbarbero.scim2.core.domain.model.resource.User
+import com.marcosbarbero.scim2.core.event.BulkOperationCompletedEvent
+import com.marcosbarbero.scim2.core.event.ResourceCreatedEvent
+import com.marcosbarbero.scim2.core.event.ResourceDeletedEvent
+import com.marcosbarbero.scim2.core.event.ResourcePatchedEvent
+import com.marcosbarbero.scim2.core.event.ResourceReplacedEvent
+import com.marcosbarbero.scim2.server.port.ResourceHandler
+import com.marcosbarbero.scim2.server.port.ScimRequestContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+class ScimProvisioningEventListenerTest {
+
+    private val client = mockk<ScimClient>(relaxed = true)
+    private val userHandler = mockk<ResourceHandler<User>>()
+    private lateinit var listener: ScimProvisioningEventListener
+
+    private val testUser = User(id = "user-123", userName = "bjensen")
+
+    @BeforeEach
+    fun setup() {
+        every { userHandler.resourceType } returns User::class.java
+        every { userHandler.endpoint } returns "/Users"
+        every { userHandler.get(eq("user-123"), any<ScimRequestContext>()) } returns testUser
+        every { client.create(any(), any<User>(), any<KClass<User>>()) } returns ScimResponse(201, testUser)
+        every { client.replace(any(), any(), any<User>(), any<KClass<User>>()) } returns ScimResponse(200, testUser)
+
+        listener = ScimProvisioningEventListener(client, listOf(userHandler))
+    }
+
+    @Test
+    fun `should provision created resource to target`() {
+        val event = ResourceCreatedEvent(resourceType = "User", resourceId = "user-123")
+
+        listener.onScimEvent(event)
+
+        verify { userHandler.get("user-123", any<ScimRequestContext>()) }
+        verify { client.create("/Users", testUser, User::class) }
+    }
+
+    @Test
+    fun `should provision replaced resource to target`() {
+        val event = ResourceReplacedEvent(resourceType = "User", resourceId = "user-123")
+
+        listener.onScimEvent(event)
+
+        verify { userHandler.get("user-123", any<ScimRequestContext>()) }
+        verify { client.replace("/Users", "user-123", testUser, User::class) }
+    }
+
+    @Test
+    fun `should provision patched resource as replace to target`() {
+        val event = ResourcePatchedEvent(resourceType = "User", resourceId = "user-123", operationCount = 1)
+
+        listener.onScimEvent(event)
+
+        verify { userHandler.get("user-123", any<ScimRequestContext>()) }
+        verify { client.replace("/Users", "user-123", testUser, User::class) }
+    }
+
+    @Test
+    fun `should provision deleted resource to target`() {
+        val event = ResourceDeletedEvent(resourceType = "User", resourceId = "user-123")
+
+        listener.onScimEvent(event)
+
+        verify { client.delete("/Users", "user-123") }
+    }
+
+    @Test
+    fun `should ignore bulk events`() {
+        val event = BulkOperationCompletedEvent(operationCount = 5)
+
+        listener.onScimEvent(event)
+
+        verify(exactly = 0) { client.create(any(), any<User>(), any<KClass<User>>()) }
+        verify(exactly = 0) { client.delete(any(), any()) }
+    }
+
+    @Test
+    fun `should not fail when handler not found for resource type`() {
+        val event = ResourceCreatedEvent(resourceType = "UnknownType", resourceId = "123")
+
+        listener.onScimEvent(event)
+
+        verify(exactly = 0) { client.create(any(), any<User>(), any<KClass<User>>()) }
+    }
+
+    @Test
+    fun `should not fail when client throws exception`() {
+        every { client.create(any(), any<User>(), any<KClass<User>>()) } throws RuntimeException("Connection refused")
+
+        val event = ResourceCreatedEvent(resourceType = "User", resourceId = "user-123")
+
+        listener.onScimEvent(event)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #58 — Adds outbound IdP provisioning so SCIM resource mutations are automatically pushed to a remote SCIM server.

### Architecture
1. **`SpringScimEventPublisher`** — Bridges `ScimEvent` to Spring `ApplicationEvent`, auto-configured as default `ScimEventPublisher` (replaces `NoOpEventPublisher`)
2. **`ScimProvisioningEventListener`** — `@EventListener` that reacts to SCIM events and pushes changes via `ScimClient`:
   - `ResourceCreatedEvent` → fetches resource, POSTs to target
   - `ResourceReplacedEvent` / `ResourcePatchedEvent` → fetches resource, PUTs to target
   - `ResourceDeletedEvent` → DELETEs on target
3. **`ScimProvisioningAutoConfiguration`** — Wires beans when enabled, creates dedicated `ScimClient` for provisioning

### Configuration
```yaml
scim:
  provisioning:
    enabled: true
    target-url: https://downstream.example.com/scim/v2
    bearer-token: <optional-token>
```

### Tests
- `SpringScimEventPublisherTest` — verifies event bridging
- `ScimProvisioningEventListenerTest` — verifies all event types, error handling, unknown types
- `ScimProvisioningAutoConfigurationTest` — verifies bean registration and conditionals

## Test plan
- [ ] CI passes
- [ ] SpringScimEventPublisher is auto-configured as default
- [ ] Provisioning listener not registered when `scim.provisioning.enabled=false`
- [ ] All CRUD events correctly provisioned to target

🤖 Generated with [Claude Code](https://claude.com/claude-code)