### PR TITLE
fix: Add error logging to KeycloakScimRealE2E setup

### DIFF
--- a/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakScimRealE2E.kt
+++ b/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/KeycloakScimRealE2E.kt
@@ -135,6 +135,8 @@ class KeycloakScimRealE2E {
             try {
                 startKeycloak()
             } catch (e: Exception) {
+                System.err.println("Keycloak SCIM E2E setup failed: ${e.message}")
+                e.printStackTrace(System.err)
                 assumeTrue(false, "Keycloak container failed to start: ${e.message}")
             }
         }
@@ -157,6 +159,16 @@ class KeycloakScimRealE2E {
             .waitingFor(Wait.forHttp("/realms/master").forStatusCode(200).withStartupTimeout(Duration.ofMinutes(3)))
 
         keycloak!!.start()
+
+        // Verify SCIM server is reachable from the test process
+        val healthCheck = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:$port/scim/v2/ServiceProviderConfig"))
+            .GET()
+            .build()
+        val healthResponse = httpClient.send(healthCheck, HttpResponse.BodyHandlers.ofString())
+        check(healthResponse.statusCode() == 200) {
+            "SCIM server not reachable at localhost:$port: ${healthResponse.statusCode()}"
+        }
 
         val adminToken = obtainAdminToken()
         createRealm(adminToken)


### PR DESCRIPTION
## Summary
The E2E test was silently skipping (1 run, 1 skipped) without logging why the setup failed.

- Print stack trace to stderr when `startKeycloak()` fails
- Add SCIM server health check (`/ServiceProviderConfig`) before configuring the Keycloak SCIM provider

This will reveal the actual error in the next CI run so we can fix the root cause.

## Test plan
- [ ] CI E2E job logs show the actual error when the test skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)