### PR TITLE
fix: Add missing schemas attribute to Schema model

### DIFF
--- a/docs/scim2-openapi.yaml
+++ b/docs/scim2-openapi.yaml
@@ -1071,7 +1071,13 @@ components:
 
     Schema:
       type: object
+      required: [schemas, id]
       properties:
+        schemas:
+          type: array
+          items:
+            type: string
+          example: ["urn:ietf:params:scim:schemas:core:2.0:Schema"]
         id:
           type: string
         name:

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/schema/Schema.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/schema/Schema.kt
@@ -15,12 +15,14 @@
  */
 package com.marcosbarbero.scim2.core.domain.model.schema
 
+import com.marcosbarbero.scim2.core.domain.ScimUrns
 import com.marcosbarbero.scim2.core.schema.annotation.AttributeType
 import com.marcosbarbero.scim2.core.schema.annotation.Mutability
 import com.marcosbarbero.scim2.core.schema.annotation.Returned
 import com.marcosbarbero.scim2.core.schema.annotation.Uniqueness
 
 data class Schema(
+    val schemas: List<String> = listOf(ScimUrns.SCHEMA),
     val id: String,
     val name: String?,
     val description: String?,

--- a/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
+++ b/scim2-sdk-server/src/test/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcherTest.kt
@@ -1426,6 +1426,24 @@ class ScimEndpointDispatcherTest {
     }
 
     @Test
+    fun `GET Schemas by id should include schemas attribute`() {
+        val schemas = discoveryService.getSchemas()
+        val schemaId = schemas.resources.first().id
+
+        val request = ScimHttpRequest(
+            method = HttpMethod.GET,
+            path = "${config.basePath}/Schemas/$schemaId",
+        )
+
+        val response = dispatcher.dispatch(request)
+
+        response.status shouldBe 200
+        val responseBody = objectMapper.readTree(response.body)
+        responseBody.has("schemas") shouldBe true
+        responseBody.get("schemas").get(0).asString() shouldBe ScimUrns.SCHEMA
+    }
+
+    @Test
     fun `GET ResourceTypes by name should return specific resource type`() {
         val request = ScimHttpRequest(
             method = HttpMethod.GET,


### PR DESCRIPTION
## Summary

The `suvera/keycloak-scim2-storage` extension validates the SCIM server during configuration and rejects our `/Schemas` endpoint:

```
Empty schemas attribute found for Schemas, Expected value is one of
[urn:ietf:params:scim:schemas:core:2.0:Schema]
```

This is the same issue as #60 (fixed for `ResourceType` and `ServiceProviderConfig` in PR #78) but we missed `Schema`. Per RFC 7643 §3, the `schemas` attribute is REQUIRED on all SCIM resources.

- Add `schemas: List<String> = listOf(ScimUrns.SCHEMA)` to `Schema` data class
- Update OpenAPI spec with `schemas` property and `required` constraint
- Add endpoint-level test for `GET /Schemas/{id}` schemas attribute

## Test plan
- [ ] CI passes
- [ ] `GET /Schemas/{id}` returns `schemas` field in JSON
- [ ] `KeycloakScimRealE2E` progresses past the SCIM provider configuration step

🤖 Generated with [Claude Code](https://claude.com/claude-code)