### PR TITLE
fix: Make create idempotent — deduplicate by externalId

### DIFF
--- a/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/persistence/adapter/JpaResourceRepository.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/main/kotlin/com/marcosbarbero/scim2/spring/persistence/adapter/JpaResourceRepository.kt
@@ -43,6 +43,14 @@ class JpaResourceRepository<T : ScimResource>(
 ) : ResourceRepository<T> {
 
     override fun create(resource: T): T {
+        // Idempotency: if a resource with the same externalId already exists, update it
+        val existingByExternalId = resource.externalId?.let {
+            jpaRepository.findByResourceTypeAndExternalId(resourceTypeName, it)
+        }
+        if (existingByExternalId != null) {
+            return replace(existingByExternalId.id, resource, null)
+        }
+
         val id = resource.id ?: UUID.randomUUID().toString()
         val now = Instant.now()
         val meta = Meta(

--- a/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/JpaResourceRepositoryTest.kt
+++ b/scim2-sdk-spring-boot-autoconfigure/src/test/kotlin/com/marcosbarbero/scim2/spring/persistence/JpaResourceRepositoryTest.kt
@@ -35,6 +35,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.boot.persistence.autoconfigure.EntityScan
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.test.context.TestPropertySource
+import java.util.UUID
 
 @DataJpaTest
 @EnableJpaRepositories(basePackages = ["com.marcosbarbero.scim2.spring.persistence.repository"])
@@ -185,6 +186,44 @@ class JpaResourceRepositoryTest {
         created.meta.shouldNotBeNull()
         created.meta!!.resourceType shouldBe "Group"
         created.displayName shouldBe displayName
+    }
+
+    @Test
+    fun `create with same externalId updates existing resource instead of duplicating`() {
+        val externalId = UUID.randomUUID().toString()
+        val user1 = User(externalId = externalId, userName = "original")
+        val created = userRepository.create(user1)
+
+        val user2 = User(externalId = externalId, userName = "updated")
+        val result = userRepository.create(user2)
+
+        result.id shouldBe created.id
+        result.userName shouldBe "updated"
+
+        val all = userRepository.search(SearchRequest())
+        all.totalResults shouldBe 1
+    }
+
+    @Test
+    fun `create without externalId always creates new resource`() {
+        val user1 = User(userName = "user-a")
+        val user2 = User(userName = "user-b")
+        userRepository.create(user1)
+        userRepository.create(user2)
+
+        val all = userRepository.search(SearchRequest())
+        all.totalResults shouldBe 2
+    }
+
+    @Test
+    fun `create with different externalIds creates separate resources`() {
+        val user1 = User(externalId = "ext-1", userName = "user-1")
+        val user2 = User(externalId = "ext-2", userName = "user-2")
+        userRepository.create(user1)
+        userRepository.create(user2)
+
+        val all = userRepository.search(SearchRequest())
+        all.totalResults shouldBe 2
     }
 
     @Test


### PR DESCRIPTION
## Summary

When an IdP's SCIM extension (e.g., suvera keycloak-scim2-storage) retries a create, the SDK creates a duplicate resource. The suvera sync job validates our server's response client-side — if validation fails (e.g., null fields from the bug fixed in PR #83), the job is marked failed but the user is already persisted in our DB. On retry, a second copy is created.

PR #83 fixes the root cause (null fields in responses). This PR adds idempotency as a safety net — retries should never create duplicates regardless of the trigger.

**Fix:** Before creating, check if a resource with the same `externalId` and `resourceType` already exists. If so, update it instead of creating a duplicate. The `findByResourceTypeAndExternalId` query already existed in `ScimResourceJpaRepository` but wasn't used during create.

Resources without an `externalId` are always created as new (no dedup).

### Tests
- `create with same externalId updates existing resource instead of duplicating` — proves idempotency
- `create without externalId always creates new resource` — no false dedup
- `create with different externalIds creates separate resources` — different externals are separate

## Test plan
- [ ] CI passes
- [ ] Create user via Keycloak SCIM extension twice → only one user in SCIM server
- [ ] Create user without externalId twice → two separate users

🤖 Generated with [Claude Code](https://claude.com/claude-code)