### PR TITLE
fix: Add id-token permission for OSSF Scorecard Sigstore signing

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

The OSSF Scorecard job has been failing on every run on main with:

```
error signing scorecard results: getting Fulcio signer: getting key from Fulcio:
retrieving cert: error obtaining token: expired_token
```

**Root cause**: `publish_results: true` requires Sigstore/Fulcio signing, which needs an OIDC token via GitHub's `id-token: write` permission. The workflow only had `security-events: write`.

**Fix**: Add `id-token: write` to the OSSF Scorecard job permissions.

## Test plan
- [ ] CVE Scan workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)