### PR TITLE
fix: Enforce returned=NEVER filtering and PATCH mutability (RFC 7643 §2.2, §3.2)

### DIFF
--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResource.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/domain/model/resource/ScimResource.kt
@@ -18,11 +18,16 @@ package com.marcosbarbero.scim2.core.domain.model.resource
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.marcosbarbero.scim2.core.domain.model.common.Meta
+import com.marcosbarbero.scim2.core.schema.annotation.Mutability
+import com.marcosbarbero.scim2.core.schema.annotation.Returned
+import com.marcosbarbero.scim2.core.schema.annotation.ScimAttribute
 
 abstract class ScimResource(
     open val schemas: List<String>,
+    @ScimAttribute(mutability = Mutability.READ_ONLY, returned = Returned.ALWAYS)
     open val id: String? = null,
     open val externalId: String? = null,
+    @ScimAttribute(mutability = Mutability.READ_ONLY, returned = Returned.DEFAULT)
     open val meta: Meta? = null,
 ) {
     private val _extensions: MutableMap<String, Any> = mutableMapOf()

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngine.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngine.kt
@@ -17,10 +17,12 @@ package com.marcosbarbero.scim2.core.patch
 
 import com.marcosbarbero.scim2.core.domain.model.error.InvalidPathException
 import com.marcosbarbero.scim2.core.domain.model.error.InvalidValueException
+import com.marcosbarbero.scim2.core.domain.model.error.MutabilityException
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchOp
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchOperation
 import com.marcosbarbero.scim2.core.domain.model.patch.PatchRequest
 import com.marcosbarbero.scim2.core.domain.model.resource.ScimResource
+import com.marcosbarbero.scim2.core.validation.MutabilityValidator
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.node.ArrayNode
@@ -32,11 +34,31 @@ class PatchEngine(private val objectMapper: ObjectMapper) {
         var node = objectMapper.valueToTree<ObjectNode>(resource)
 
         for (operation in request.operations) {
+            validateMutability(resource::class, operation)
             node = applyOperation(node, operation)
         }
 
         @Suppress("UNCHECKED_CAST")
         return objectMapper.treeToValue(node, resource::class.java) as T
+    }
+
+    private fun validateMutability(resourceClass: kotlin.reflect.KClass<*>, operation: PatchOperation) {
+        val path = operation.path
+        if (path != null) {
+            if (!MutabilityValidator.isModificationAllowed(resourceClass, path)) {
+                throw MutabilityException("Attribute '$path' is not modifiable")
+            }
+        } else {
+            // No path: value must be an object. Check each field in it.
+            val value = operation.value
+            if (value is ObjectNode) {
+                value.propertyNames().forEach { fieldName ->
+                    if (!MutabilityValidator.isModificationAllowed(resourceClass, fieldName)) {
+                        throw MutabilityException("Attribute '$fieldName' is not modifiable")
+                    }
+                }
+            }
+        }
     }
 
     private fun applyOperation(node: ObjectNode, operation: PatchOperation): ObjectNode = when (operation.op) {

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/serialization/jackson/JacksonScimSerializer.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/serialization/jackson/JacksonScimSerializer.kt
@@ -16,6 +16,8 @@
 package com.marcosbarbero.scim2.core.serialization.jackson
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.marcosbarbero.scim2.core.schema.annotation.Returned
+import com.marcosbarbero.scim2.core.schema.annotation.ScimAttribute
 import com.marcosbarbero.scim2.core.serialization.spi.ScimSerializer
 import tools.jackson.databind.DeserializationFeature
 import tools.jackson.databind.ObjectMapper
@@ -23,6 +25,8 @@ import tools.jackson.databind.json.JsonMapper
 import tools.jackson.databind.node.ObjectNode
 import tools.jackson.module.kotlin.KotlinModule
 import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaField
 
 class JacksonScimSerializer(private val objectMapper: ObjectMapper) : ScimSerializer {
 
@@ -51,6 +55,17 @@ class JacksonScimSerializer(private val objectMapper: ObjectMapper) : ScimSerial
         return objectMapper.writeValueAsBytes(tree)
     }
 
+    override fun filterReturnedNever(json: ByteArray, resourceClass: Class<*>): ByteArray {
+        val neverFields = resolveReturnedNeverFields(resourceClass.kotlin)
+        if (neverFields.isEmpty()) return json
+
+        val tree = objectMapper.readTree(json) as ObjectNode
+        for (field in neverFields) {
+            tree.remove(field)
+        }
+        return objectMapper.writeValueAsBytes(tree)
+    }
+
     override fun enrichMemberRefs(json: ByteArray, baseScimUrl: String): ByteArray {
         val tree = objectMapper.readTree(json) as ObjectNode
         val base = baseScimUrl.trimEnd('/')
@@ -71,7 +86,21 @@ class JacksonScimSerializer(private val objectMapper: ObjectMapper) : ScimSerial
         }
     }
 
+    private fun resolveReturnedNeverFields(klass: KClass<*>): Set<String> = returnedNeverCache.getOrPut(klass) {
+        klass.memberProperties
+            .filter { prop ->
+                val annotation = prop.javaField?.getAnnotation(ScimAttribute::class.java)
+                    ?: prop.annotations.filterIsInstance<ScimAttribute>().firstOrNull()
+                    ?: prop.getter.annotations.filterIsInstance<ScimAttribute>().firstOrNull()
+                annotation?.returned == Returned.NEVER
+            }
+            .map { it.name }
+            .toSet()
+    }
+
     companion object {
+        private val returnedNeverCache = java.util.concurrent.ConcurrentHashMap<KClass<*>, Set<String>>()
+
         fun defaultObjectMapper(): ObjectMapper = JsonMapper.builder()
             .addModule(KotlinModule.Builder().build())
             .addModule(ScimModule())

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/serialization/spi/ScimSerializer.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/serialization/spi/ScimSerializer.kt
@@ -36,6 +36,16 @@ interface ScimSerializer {
     fun enrichMetaLocation(json: ByteArray, location: String, resourceType: String? = null): ByteArray
 
     /**
+     * Removes fields annotated with `@ScimAttribute(returned = Returned.NEVER)` from
+     * already-serialized JSON bytes. Operates on wire format to avoid lossy round-trips.
+     *
+     * @param json the serialized JSON bytes
+     * @param resourceClass the resource class whose annotations drive filtering
+     * @return filtered JSON bytes with returned=NEVER fields removed
+     */
+    fun filterReturnedNever(json: ByteArray, resourceClass: Class<*>): ByteArray = json
+
+    /**
      * Enriches already-serialized JSON bytes by setting `$ref` on `members` and `groups` arrays.
      *
      * For each member/group entry that has a `value` (ID) and `type` but no `$ref`,

--- a/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/validation/MutabilityValidator.kt
+++ b/scim2-sdk-core/src/main/kotlin/com/marcosbarbero/scim2/core/validation/MutabilityValidator.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Marcos Barbero
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.marcosbarbero.scim2.core.validation
+
+import com.marcosbarbero.scim2.core.schema.annotation.Mutability
+import com.marcosbarbero.scim2.core.schema.annotation.ScimAttribute
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaField
+
+/**
+ * Validates whether an attribute path is allowed to be modified on a given resource class
+ * based on the `@ScimAttribute(mutability = ...)` annotation.
+ *
+ * Per RFC 7643 §7:
+ * - READ_ONLY attributes cannot be modified (ever)
+ * - IMMUTABLE attributes can only be set on creation (not via PATCH/PUT)
+ */
+object MutabilityValidator {
+
+    private val mutabilityCache = ConcurrentHashMap<KClass<*>, Map<String, Mutability>>()
+
+    /**
+     * Returns `true` if the attribute at the given [path] is allowed to be modified
+     * via PATCH or PUT on the given [resourceClass].
+     *
+     * Attributes without a `@ScimAttribute` annotation are assumed to be READ_WRITE.
+     * Filter paths (e.g., `emails[type eq "work"]`) use only the base attribute name.
+     */
+    @JvmStatic
+    fun isModificationAllowed(resourceClass: KClass<*>, path: String): Boolean {
+        val basePath = extractBasePath(path)
+        val mutabilityMap = resolveMutabilityMap(resourceClass)
+        val mutability = mutabilityMap[basePath.lowercase()] ?: return true
+        return mutability != Mutability.READ_ONLY && mutability != Mutability.IMMUTABLE
+    }
+
+    private fun resolveMutabilityMap(klass: KClass<*>): Map<String, Mutability> = mutabilityCache.getOrPut(klass) {
+        val result = mutableMapOf<String, Mutability>()
+        // Check all member properties (includes inherited) via Kotlin reflection
+        klass.memberProperties.forEach { prop ->
+            val annotation = findScimAttribute(prop)
+            if (annotation != null) {
+                result.putIfAbsent(prop.name.lowercase(), annotation.mutability)
+            }
+        }
+        // Walk the class hierarchy for constructor parameter annotations on superclasses
+        collectSuperclassAnnotations(klass, result)
+        result
+    }
+
+    private fun findScimAttribute(prop: kotlin.reflect.KProperty<*>): ScimAttribute? = prop.javaField?.getAnnotation(ScimAttribute::class.java)
+        ?: prop.annotations.filterIsInstance<ScimAttribute>().firstOrNull()
+        ?: prop.getter.annotations.filterIsInstance<ScimAttribute>().firstOrNull()
+
+    private fun collectSuperclassAnnotations(klass: KClass<*>, result: MutableMap<String, Mutability>) {
+        val supertypes = klass.supertypes
+        for (supertype in supertypes) {
+            val superClass = supertype.classifier as? KClass<*> ?: continue
+            if (superClass == Any::class) continue
+            // Check declared properties of the superclass directly
+            superClass.declaredMemberProperties.forEach { prop ->
+                val annotation = findScimAttribute(prop)
+                if (annotation != null) {
+                    result.putIfAbsent(prop.name.lowercase(), annotation.mutability)
+                }
+            }
+            // Recurse
+            collectSuperclassAnnotations(superClass, result)
+        }
+    }
+
+    private fun extractBasePath(path: String): String {
+        val bracketIndex = path.indexOf('[')
+        return if (bracketIndex > 0) path.substring(0, bracketIndex) else path
+    }
+}

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngineTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/patch/PatchEngineTest.kt
@@ -246,6 +246,52 @@ class PatchEngineTest {
     }
 
     @Nested
+    inner class MutabilityEnforcement {
+
+        @Test
+        fun `should reject PATCH on readOnly attribute id`() {
+            val user = baseUser()
+            val request = PatchRequest(
+                operations = listOf(
+                    PatchOperation(op = PatchOp.REPLACE, path = "id", value = objectMapper.valueToTree("new-id")),
+                ),
+            )
+
+            shouldThrow<com.marcosbarbero.scim2.core.domain.model.error.MutabilityException> {
+                engine.apply(user, request)
+            }
+        }
+
+        @Test
+        fun `should reject PATCH on readOnly attribute meta`() {
+            val user = baseUser()
+            val request = PatchRequest(
+                operations = listOf(
+                    PatchOperation(op = PatchOp.REPLACE, path = "meta", value = objectMapper.valueToTree(mapOf("resourceType" to "Hacked"))),
+                ),
+            )
+
+            shouldThrow<com.marcosbarbero.scim2.core.domain.model.error.MutabilityException> {
+                engine.apply(user, request)
+            }
+        }
+
+        @Test
+        fun `should allow PATCH on readWrite attribute displayName`() {
+            val user = baseUser()
+            val newDisplayName = faker.name.name()
+            val request = PatchRequest(
+                operations = listOf(
+                    PatchOperation(op = PatchOp.REPLACE, path = "displayName", value = objectMapper.valueToTree(newDisplayName)),
+                ),
+            )
+
+            val result = engine.apply(user, request)
+            result.displayName shouldBe newDisplayName
+        }
+    }
+
+    @Nested
     inner class PreservesIdentity {
 
         @Test

--- a/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/serialization/jackson/JacksonScimSerializerTest.kt
+++ b/scim2-sdk-core/src/test/kotlin/com/marcosbarbero/scim2/core/serialization/jackson/JacksonScimSerializerTest.kt
@@ -414,6 +414,43 @@ class JacksonScimSerializerTest {
     }
 
     @Nested
+    inner class FilterReturnedNeverTest {
+        @Test
+        fun `should exclude returned NEVER attributes from serialized output`() {
+            val user = User(userName = "secret.user", password = "s3cret!")
+            val bytes = serializer.serialize(user)
+
+            val filtered = serializer.filterReturnedNever(bytes, User::class.java)
+            val json = String(filtered, Charsets.UTF_8)
+
+            json shouldNotContain "\"password\""
+            json shouldNotContain "s3cret!"
+        }
+
+        @Test
+        fun `should preserve other attributes when filtering returned NEVER`() {
+            val user = User(
+                userName = "visible.user",
+                displayName = "Visible User",
+                password = "s3cret!",
+                emails = listOf(MultiValuedAttribute(value = "test@example.com", type = "work")),
+            )
+            val bytes = serializer.serialize(user)
+
+            val filtered = serializer.filterReturnedNever(bytes, User::class.java)
+            val json = String(filtered, Charsets.UTF_8)
+
+            json shouldContain "\"userName\""
+            json shouldContain "visible.user"
+            json shouldContain "\"displayName\""
+            json shouldContain "Visible User"
+            json shouldContain "\"emails\""
+            json shouldContain "test@example.com"
+            json shouldNotContain "\"password\""
+        }
+    }
+
+    @Nested
     inner class EnrichMemberRefsTest {
         @Test
         fun `should add ref to group members`() {

--- a/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/ScimRfcComplianceE2E.kt
+++ b/scim2-sdk-samples/sample-server-spring/src/test/kotlin/com/marcosbarbero/scim2/sample/spring/ScimRfcComplianceE2E.kt
@@ -324,6 +324,56 @@ class ScimRfcComplianceE2E(@LocalServerPort val port: Int) {
         json["scimType"].stringValue() shouldBe "invalidFilter"
     }
 
+    // === returned=NEVER filtering (RFC 7643 §7, Issue #99) ===
+
+    @Test
+    fun `POST with password does not return password in response body`() {
+        val user = User(userName = "rfc.password.${System.nanoTime()}", password = "SuperSecret123!")
+        val httpClient = java.net.http.HttpClient.newHttpClient()
+        val serializer = JacksonScimSerializer()
+        val request = java.net.http.HttpRequest.newBuilder()
+            .uri(java.net.URI.create("http://localhost:$port/scim/v2/Users"))
+            .header("Content-Type", "application/scim+json")
+            .POST(java.net.http.HttpRequest.BodyPublishers.ofByteArray(serializer.serialize(user)))
+            .build()
+        val response = httpClient.send(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+        val json = response.body()
+
+        response.statusCode() shouldBe 201
+        json shouldContain "\"userName\""
+        json shouldNotContain "\"password\""
+        json shouldNotContain "SuperSecret123!"
+    }
+
+    // === Mutability enforcement (RFC 7643 §7, Issue #100) ===
+
+    @Test
+    fun `PATCH on readOnly attribute returns 400 mutability`() {
+        val created = client.create<User>("/Users", User(userName = "rfc.mutability.${System.nanoTime()}"))
+        val id = created.value.id!!
+
+        val patchJson = """
+        {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [
+                {"op": "replace", "path": "id", "value": "hacked-id"}
+            ]
+        }
+        """.trimIndent()
+
+        val httpClient = java.net.http.HttpClient.newHttpClient()
+        val request = java.net.http.HttpRequest.newBuilder()
+            .uri(java.net.URI.create("http://localhost:$port/scim/v2/Users/$id"))
+            .header("Content-Type", "application/scim+json")
+            .method("PATCH", java.net.http.HttpRequest.BodyPublishers.ofString(patchJson))
+            .build()
+        val response = httpClient.send(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+        val json = objectMapper.readTree(response.body())
+
+        response.statusCode() shouldBe 400
+        json["scimType"].stringValue() shouldBe "mutability"
+    }
+
     // === Verify raw JSON wire format ===
 
     @Test

--- a/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcher.kt
+++ b/scim2-sdk-server/src/main/kotlin/com/marcosbarbero/scim2/server/adapter/http/ScimEndpointDispatcher.kt
@@ -256,6 +256,7 @@ class ScimEndpointDispatcher(
                 val locationHeader = absoluteLocation ?: relativeLocation ?: "${config.basePath}${handler.endpoint}"
                 var bytes = serializer.serialize(created)
                 bytes = enrichSerializedMetaLocation(bytes, absoluteLocation, resourceTypeName)
+                bytes = serializer.filterReturnedNever(bytes, handler.resourceType)
                 val enrichedBytes = enrichMemberRefs(bytes)
                 eventPublisher.publish(
                     ResourceCreatedEvent(
@@ -294,6 +295,7 @@ class ScimEndpointDispatcher(
                     } else {
                         var bytes = serializer.serialize(result)
                         bytes = enrichSerializedMetaLocation(bytes, absoluteLocation, resourceTypeName)
+                        bytes = serializer.filterReturnedNever(bytes, handler.resourceType)
                         bytes = enrichMemberRefs(bytes)
                         ScimHttpResponse.ok(
                             bytes,
@@ -317,7 +319,7 @@ class ScimEndpointDispatcher(
                         correlationId = tracer.currentCorrelationId(),
                     ),
                 )
-                okWithEnrichedBytes(result, absoluteLocation, resourceTypeName)
+                okWithEnrichedBytes(result, absoluteLocation, resourceTypeName, handler.resourceType)
             }
 
             HttpMethod.PATCH -> {
@@ -342,7 +344,7 @@ class ScimEndpointDispatcher(
                         operationCount = patchRequest.operations.size,
                     ),
                 )
-                okWithEnrichedBytes(result, absoluteLocation, resourceTypeName)
+                okWithEnrichedBytes(result, absoluteLocation, resourceTypeName, handler.resourceType)
             }
 
             HttpMethod.DELETE -> {
@@ -438,9 +440,13 @@ class ScimEndpointDispatcher(
         resource: T,
         absoluteLocation: String?,
         resourceType: String?,
+        resourceClass: Class<*>? = null,
     ): ScimHttpResponse {
         var bytes = serializer.serialize(resource)
         bytes = enrichSerializedMetaLocation(bytes, absoluteLocation, resourceType)
+        if (resourceClass != null) {
+            bytes = serializer.filterReturnedNever(bytes, resourceClass)
+        }
         bytes = enrichMemberRefs(bytes)
         return ScimHttpResponse.ok(bytes)
     }
@@ -463,6 +469,7 @@ class ScimEndpointDispatcher(
                 val location = "$baseScimUrl${handler.endpoint}/${resource.id}"
                 bytes = serializer.enrichMetaLocation(bytes, location, resourceTypeName)
             }
+            bytes = serializer.filterReturnedNever(bytes, handler.resourceType)
             bytes = serializer.enrichMemberRefs(bytes, baseScimUrl)
             bytes
         }


### PR DESCRIPTION
## Summary

Two final RFC 7643 compliance gaps from the audit:

### Issue #99: Password and returned=NEVER attributes leak in responses

Attributes annotated with `@ScimAttribute(returned = Returned.NEVER)` were not filtered from responses. Password could leak if set.

**Fix**: `ScimSerializer.filterReturnedNever()` uses reflection to find NEVER fields, strips them from serialized JSON. Called on all dispatcher response paths. Results cached per class via ConcurrentHashMap.

### Issue #100: PATCH on READ_ONLY/IMMUTABLE attributes succeeds silently

`PatchEngine` applied operations without checking mutability annotations. Clients could PATCH `id` or `meta`.

**Fix**: `MutabilityValidator` resolves `@ScimAttribute(mutability=...)` via reflection, walks class hierarchy. `PatchEngine.validateMutability()` checks each operation before applying. Throws `MutabilityException` (400, scimType: mutability) for READ_ONLY and IMMUTABLE attributes.

### Tests

| Level | Tests | What |
|---|---|---|
| Unit | 2 FilterReturnedNeverTest | NEVER excluded, others preserved |
| Unit | 3 PatchEngineTest | Reject id, reject meta, allow displayName |
| E2E | 2 ScimRfcComplianceE2E | Password absent in response, PATCH mutability 400 |

Closes #99, closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)