### PR TITLE
feat: Add Playwright E2E tests for React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ out/
 *.log
 hs_err_pid*
 .claude/
+
+# Playwright
+.auth/
+test-results/
+playwright-report/

--- a/scim2-sdk-samples/sample-fullstack-spring/README.md
+++ b/scim2-sdk-samples/sample-fullstack-spring/README.md
@@ -136,6 +136,31 @@ These are limitations of the suvera extension, not the SDK. All SCIM operations 
 
 For full bidirectional sync with Keycloak, consider using a SCIM extension that supports all operations (e.g., the commercial [scim-for-keycloak](https://scim-for-keycloak.de/) or [mitodl/keycloak-scim](https://github.com/mitodl/keycloak-scim)).
 
+## Playwright E2E Tests
+
+End-to-end tests exercise the full stack (Keycloak, Spring Boot SCIM servers, React frontend) through the browser.
+
+**Prerequisites:** The full stack must be running (`docker compose up -d`).
+
+```bash
+cd scim2-sdk-samples/shared-frontend
+npm install
+npx playwright install --with-deps chromium
+npx playwright test
+```
+
+To run tests in headed mode (visible browser):
+
+```bash
+npx playwright test --headed
+```
+
+To open the Playwright UI for interactive debugging:
+
+```bash
+npx playwright test --ui
+```
+
 ## Local Development
 
 ```bash

--- a/scim2-sdk-samples/shared-frontend/e2e/auth.setup.js
+++ b/scim2-sdk-samples/shared-frontend/e2e/auth.setup.js
@@ -1,0 +1,28 @@
+import { test as setup, expect } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+
+setup('authenticate', async ({ page }) => {
+  // Ensure the .auth directory exists
+  await mkdir('.auth', { recursive: true });
+
+  // Navigate to the app -- Keycloak login is triggered via keycloak-js
+  await page.goto('/');
+
+  // Click the "Log In with Keycloak" button rendered by the React app
+  await page.getByRole('button', { name: 'Log In with Keycloak' }).click();
+
+  // Wait for the Keycloak login page to load
+  await page.waitForURL('**/realms/**');
+
+  // Fill in credentials on the Keycloak login form
+  await page.locator('#username').fill('admin');
+  await page.locator('#password').fill('admin');
+  await page.locator('#kc-login').click();
+
+  // Wait for redirect back to the app (authenticated state shows the nav bar)
+  await page.waitForURL('**/users');
+  await expect(page.getByText('SCIM Sample')).toBeVisible();
+
+  // Save authentication state so other tests can reuse the session
+  await page.context().storageState({ path: '.auth/state.json' });
+});

--- a/scim2-sdk-samples/shared-frontend/e2e/groups.spec.js
+++ b/scim2-sdk-samples/shared-frontend/e2e/groups.spec.js
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+// Generate a unique suffix so parallel runs do not collide
+const unique = () => Date.now().toString(36);
+
+test.describe('Group Management', () => {
+
+  test('should display the groups list page', async ({ page }) => {
+    await page.goto('/groups');
+
+    await expect(page.getByRole('heading', { name: 'Groups' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '+ New Group' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Display Name' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Members' })).toBeVisible();
+  });
+
+  test('should create a new group', async ({ page }) => {
+    const groupName = `pw-group-${unique()}`;
+
+    await page.goto('/groups');
+    await page.getByRole('button', { name: '+ New Group' }).click();
+    await page.waitForURL('**/groups/new');
+
+    // Fill the group form
+    await page.getByLabel('Display Name').fill(groupName);
+
+    // Submit
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    // Should redirect to the groups list
+    await page.waitForURL('**/groups');
+
+    // The new group should appear in the table
+    await expect(page.getByRole('cell', { name: groupName })).toBeVisible();
+  });
+
+  test('should delete a group', async ({ page }) => {
+    // Create a group to delete
+    const groupName = `pw-grpdel-${unique()}`;
+    await page.goto('/groups/new');
+    await page.getByLabel('Display Name').fill(groupName);
+    await page.getByRole('button', { name: 'Create' }).click();
+    await page.waitForURL('**/groups');
+    await expect(page.getByRole('cell', { name: groupName })).toBeVisible();
+
+    // Accept the confirmation dialog before clicking delete
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Find the row containing our group and click its Delete button
+    const row = page.getByRole('row').filter({ hasText: groupName });
+    await row.getByRole('button', { name: 'Delete' }).click();
+
+    // The group should no longer appear
+    await expect(page.getByRole('cell', { name: groupName })).toBeHidden({ timeout: 10000 });
+  });
+});

--- a/scim2-sdk-samples/shared-frontend/e2e/users.spec.js
+++ b/scim2-sdk-samples/shared-frontend/e2e/users.spec.js
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+// Generate a unique suffix so parallel runs do not collide
+const unique = () => Date.now().toString(36);
+
+test.describe('User Management', () => {
+
+  test('should display the users list page', async ({ page }) => {
+    await page.goto('/users');
+
+    // The heading and "New User" button should be visible
+    await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '+ New User' })).toBeVisible();
+
+    // The table header should include expected columns
+    await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Display Name' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Email' })).toBeVisible();
+  });
+
+  test('should create a new user', async ({ page }) => {
+    const userName = `pw-user-${unique()}`;
+
+    await page.goto('/users');
+    await page.getByRole('button', { name: '+ New User' }).click();
+    await page.waitForURL('**/users/new');
+
+    // Fill out the user form
+    await page.getByLabel('Username').fill(userName);
+    await page.getByLabel('Display Name').fill(`Playwright Test ${userName}`);
+    await page.getByLabel('Given Name').fill('Play');
+    await page.getByLabel('Family Name').fill('Wright');
+    await page.getByLabel('Email').fill(`${userName}@test.local`);
+
+    // Submit
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    // Should redirect to the user list
+    await page.waitForURL('**/users');
+
+    // The new user should appear in the table
+    await expect(page.getByRole('cell', { name: userName })).toBeVisible();
+  });
+
+  test('should search and filter users', async ({ page }) => {
+    // Create a user to search for
+    const userName = `pw-filter-${unique()}`;
+    await page.goto('/users/new');
+    await page.getByLabel('Username').fill(userName);
+    await page.getByLabel('Display Name').fill(`Filterable ${userName}`);
+    await page.getByRole('button', { name: 'Create' }).click();
+    await page.waitForURL('**/users');
+
+    // Type a SCIM filter in the search box and click Search
+    const searchInput = page.getByPlaceholder('Search users');
+    await searchInput.fill(`userName eq "${userName}"`);
+    await page.getByRole('button', { name: 'Search' }).click();
+
+    // Wait for the filtered result to load
+    await expect(page.getByText('1 user(s) found')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('cell', { name: userName })).toBeVisible();
+  });
+
+  test('should delete a user', async ({ page }) => {
+    // Create a user to delete
+    const userName = `pw-del-${unique()}`;
+    await page.goto('/users/new');
+    await page.getByLabel('Username').fill(userName);
+    await page.getByLabel('Display Name').fill(`Deletable ${userName}`);
+    await page.getByRole('button', { name: 'Create' }).click();
+    await page.waitForURL('**/users');
+    await expect(page.getByRole('cell', { name: userName })).toBeVisible();
+
+    // Accept the confirmation dialog before clicking delete
+    page.on('dialog', (dialog) => dialog.accept());
+
+    // Find the row containing our user and click its Delete button
+    const row = page.getByRole('row').filter({ hasText: userName });
+    await row.getByRole('button', { name: 'Delete' }).click();
+
+    // The user should no longer appear
+    await expect(page.getByRole('cell', { name: userName })).toBeHidden({ timeout: 10000 });
+  });
+});

--- a/scim2-sdk-samples/shared-frontend/package.json
+++ b/scim2-sdk-samples/shared-frontend/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "keycloak-js": "^26.0.0",
@@ -15,6 +18,7 @@
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/scim2-sdk-samples/shared-frontend/playwright.config.js
+++ b/scim2-sdk-samples/shared-frontend/playwright.config.js
@@ -1,0 +1,27 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  retries: 1,
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'auth-setup',
+      testMatch: /auth\.setup\.js/,
+    },
+    {
+      name: 'e2e',
+      dependencies: ['auth-setup'],
+      use: {
+        storageState: '.auth/state.json',
+      },
+    },
+  ],
+  webServer: undefined, // Tests run against an already-running stack
+});


### PR DESCRIPTION
## Summary

Browser-based E2E tests for the React frontend using Playwright. Tests validate the full user flow through the UI against a running Docker Compose stack.

### Tests (7 total)

**auth.setup.js** — Keycloak login flow
- Navigates to app, redirects to Keycloak, logs in as admin, saves session

**users.spec.js** — User management
- Display users list page (heading, table columns)
- Create a new user (fill form, submit, verify in list)
- Search/filter users (type in search box, verify filtered results)
- Delete a user (click delete, confirm, verify removed)

**groups.spec.js** — Group management
- Display groups list page
- Create a new group
- Delete a group

### How to run

```bash
# Start the full stack
cd scim2-sdk-samples/sample-fullstack-spring
docker compose up -d

# Run Playwright tests
cd ../shared-frontend
npx playwright install
npx playwright test
```

### Design decisions
- Role-based locators (`getByRole`, `getByLabel`) — no fragile CSS selectors
- Unique timestamps in test data to prevent collisions
- Auth state saved to `.auth/state.json` and reused across tests
- Tests run against `http://localhost:5173` (the Docker frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)